### PR TITLE
add support for preset opacities in colors using rgba()

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Any pair of colors `X-light` and `X-dark` will yield a new color `X` that automa
 
 - You can also use the plugin with scoped tailwind color configuration such as `textColor`, `backgroundColor`, `borderColor` or `outlineColor`.
 
+- To hardcode opacity values in your tailwind config, you can use rgba `rgba(255, 255, 255, 0.2)` or hex `#ffffff33`
+
 ## Options
 
 If for some reason `-light` and `-dark` are not right for your use case, you can pass an options object as a second parameter and customize the suffixes. Just replace `"light"` and `"dark"` with any other string.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-mode-aware-colors",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "TailwindCSS Plugin to generate dynamic colors that will automatically switch between light and dark mode variants.",
   "main": "src/index.js",
   "license": "MIT",
@@ -26,7 +26,7 @@
   "devDependencies": {
     "jest": "^27.2.4",
     "postcss": "^8.2.4",
-    "tailwindcss": "^3.0.0"
+    "tailwindcss": "3.1.0 - 3.3.2"
   },
   "author": "Javier Morales"
 }

--- a/src/index.js
+++ b/src/index.js
@@ -41,20 +41,41 @@ const processColors = (
         if (colors[modeAwareColorName]) {
           throw `withModeAwareColors plugin error: adding the '${modeAwareColorName}' mode-aware color would overwrite an existing color.`;
         } else {
-          const varName = `--color-${
+          const colorName = `--color-${
             variablePrefix ? `${variablePrefix}-` : ""
           }${modeAwareColorName}`;
-          colors[modeAwareColorName] = `rgba(var(${varName}))`;
 
-          const lightStyle = Color(lightColor).rgb().array().join(", ");
-          const darkStyle = Color(darkColor).rgb().array().join(", ");
+          const opacityName = `--opacity-${
+            variablePrefix ? `${variablePrefix}-` : ""
+          }${modeAwareColorName}`;
 
-          styles.html[varName] = lightStyle;
+          colors[modeAwareColorName] = `rgb(var(${colorName}) / calc(var(${opacityName}, 1) * <alpha-value>))`;
+
+          const lightArray = Color(lightColor).rgb().array();
+          const lightColorStyle = lightArray.slice(0, 3).join(" ");
+          const lightOpacityStyle = lightArray.length > 3 ? `${lightArray[3] * 100}%` : undefined;
+          
+          const darkArray = Color(darkColor).rgb().array();
+          const darkColorStyle = darkArray.slice(0, 3).join(" ");
+          const darkOpacityStyle = darkArray.length > 3 ? `${darkArray[3] * 100}%` : undefined;
+
+          styles.html[colorName] = lightColorStyle;
+          if (lightOpacityStyle) {
+            styles.html[opacityName] = lightOpacityStyle;
+          }
+
           if (usesMediaStrategy) {
-            styles["@media (prefers-color-scheme: dark)"].html[varName] =
-              darkStyle;
+            styles["@media (prefers-color-scheme: dark)"].html[colorName] =
+              darkColorStyle;
+            if (darkOpacityStyle) {
+              styles["@media (prefers-color-scheme: dark)"].html[opacityName] =
+                darkOpacityStyle;
+            }
           } else {
-            styles[darkSelector][varName] = darkStyle;
+            styles[darkSelector][colorName] = darkColorStyle;
+            if (darkOpacityStyle) {
+              styles[darkSelector][opacityName] = darkOpacityStyle;
+            }
           }
         }
       }

--- a/src/index.js
+++ b/src/index.js
@@ -44,10 +44,10 @@ const processColors = (
           const varName = `--color-${
             variablePrefix ? `${variablePrefix}-` : ""
           }${modeAwareColorName}`;
-          colors[modeAwareColorName] = `rgb(var(${varName}) / <alpha-value>)`;
+          colors[modeAwareColorName] = `rgba(var(${varName}))`;
 
-          const lightStyle = Color(lightColor).rgb().array().join(" ");
-          const darkStyle = Color(darkColor).rgb().array().join(" ");
+          const lightStyle = Color(lightColor).rgb().array().join(", ");
+          const darkStyle = Color(darkColor).rgb().array().join(", ");
 
           styles.html[varName] = lightStyle;
           if (usesMediaStrategy) {

--- a/tests/backgroundColor.test.js
+++ b/tests/backgroundColor.test.js
@@ -18,7 +18,7 @@ describe("backgroundColor theme", () => {
       expect.objectContaining({
         theme: {
           backgroundColor: {
-            a: "rgba(var(--color-background-a))",
+            a: "rgb(var(--color-background-a) / calc(var(--opacity-background-a, 1) * <alpha-value>))",
             "a-light": "#ffffff",
             "a-dark": "#000000",
           },
@@ -47,7 +47,7 @@ describe("backgroundColor theme", () => {
           theme: {
             extend: {
               backgroundColor: {
-                a: "rgba(var(--color-background-a))",
+                a: "rgb(var(--color-background-a) / calc(var(--opacity-background-a, 1) * <alpha-value>))",
                 "a-light": "#ffffff",
                 "a-dark": "#000000",
               },
@@ -94,7 +94,7 @@ describe("backgroundColor theme", () => {
         expect(utilitiesCSS.replace(/\n|\s|\t/g, "")).toBe(
           `
           .bg-a\\/50 {
-            background-color: rgba(var(--color-background-a), 0.5)
+            background-color: rgb(var(--color-background-a) / calc(var(--opacity-background-a, 1) * 0.5))
           }
           `.replace(/\n|\s|\t/g, "")
         );
@@ -105,12 +105,12 @@ describe("backgroundColor theme", () => {
 
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `html {
-          --color-background-a: 255, 255, 255;
+          --color-background-a: 255 255 255;
         }`.replace(/\n|\s|\t/g, "")
         );
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `${expectedSelector} {
-          --color-background-a: 0, 0, 0;
+          --color-background-a: 0 0 0;
         }`.replace(/\n|\s|\t/g, "")
         );
       });

--- a/tests/backgroundColor.test.js
+++ b/tests/backgroundColor.test.js
@@ -18,7 +18,7 @@ describe("backgroundColor theme", () => {
       expect.objectContaining({
         theme: {
           backgroundColor: {
-            a: "rgb(var(--color-background-a) / <alpha-value>)",
+            a: "rgba(var(--color-background-a))",
             "a-light": "#ffffff",
             "a-dark": "#000000",
           },
@@ -47,7 +47,7 @@ describe("backgroundColor theme", () => {
           theme: {
             extend: {
               backgroundColor: {
-                a: "rgb(var(--color-background-a) / <alpha-value>)",
+                a: "rgba(var(--color-background-a))",
                 "a-light": "#ffffff",
                 "a-dark": "#000000",
               },
@@ -94,7 +94,7 @@ describe("backgroundColor theme", () => {
         expect(utilitiesCSS.replace(/\n|\s|\t/g, "")).toBe(
           `
           .bg-a\\/50 {
-            background-color: rgb(var(--color-background-a) / 0.5)
+            background-color: rgba(var(--color-background-a), 0.5)
           }
           `.replace(/\n|\s|\t/g, "")
         );
@@ -105,12 +105,12 @@ describe("backgroundColor theme", () => {
 
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `html {
-          --color-background-a: 255 255 255;
+          --color-background-a: 255, 255, 255;
         }`.replace(/\n|\s|\t/g, "")
         );
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `${expectedSelector} {
-          --color-background-a: 0 0 0;
+          --color-background-a: 0, 0, 0;
         }`.replace(/\n|\s|\t/g, "")
         );
       });

--- a/tests/borderColor.test.js
+++ b/tests/borderColor.test.js
@@ -18,7 +18,7 @@ describe("borderColor theme", () => {
       expect.objectContaining({
         theme: {
           borderColor: {
-            a: "rgba(var(--color-border-a))",
+            a: "rgb(var(--color-border-a) / calc(var(--opacity-border-a, 1) * <alpha-value>))",
             "a-light": "#ffffff",
             "a-dark": "#000000",
           },
@@ -47,7 +47,7 @@ describe("borderColor theme", () => {
           theme: {
             extend: {
               borderColor: {
-                a: "rgba(var(--color-border-a))",
+                a: "rgb(var(--color-border-a) / calc(var(--opacity-border-a, 1) * <alpha-value>))",
                 "a-light": "#ffffff",
                 "a-dark": "#000000",
               },
@@ -94,7 +94,7 @@ describe("borderColor theme", () => {
         expect(utilitiesCSS.replace(/\n|\s|\t/g, "")).toBe(
           `
           .border-a\\/50 {
-            border-color: rgba(var(--color-border-a), 0.5)
+            border-color: rgb(var(--color-border-a) / calc(var(--opacity-border-a, 1) * 0.5))
           }
           `.replace(/\n|\s|\t/g, "")
         );
@@ -105,12 +105,12 @@ describe("borderColor theme", () => {
 
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `html {
-          --color-border-a: 255, 255, 255;
+          --color-border-a: 255 255 255;
         }`.replace(/\n|\s|\t/g, "")
         );
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `${expectedSelector} {
-          --color-border-a: 0, 0, 0;
+          --color-border-a: 0 0 0;
         }`.replace(/\n|\s|\t/g, "")
         );
       });

--- a/tests/borderColor.test.js
+++ b/tests/borderColor.test.js
@@ -18,7 +18,7 @@ describe("borderColor theme", () => {
       expect.objectContaining({
         theme: {
           borderColor: {
-            a: "rgb(var(--color-border-a) / <alpha-value>)",
+            a: "rgba(var(--color-border-a))",
             "a-light": "#ffffff",
             "a-dark": "#000000",
           },
@@ -47,7 +47,7 @@ describe("borderColor theme", () => {
           theme: {
             extend: {
               borderColor: {
-                a: "rgb(var(--color-border-a) / <alpha-value>)",
+                a: "rgba(var(--color-border-a))",
                 "a-light": "#ffffff",
                 "a-dark": "#000000",
               },
@@ -94,7 +94,7 @@ describe("borderColor theme", () => {
         expect(utilitiesCSS.replace(/\n|\s|\t/g, "")).toBe(
           `
           .border-a\\/50 {
-            border-color: rgb(var(--color-border-a) / 0.5)
+            border-color: rgba(var(--color-border-a), 0.5)
           }
           `.replace(/\n|\s|\t/g, "")
         );
@@ -105,12 +105,12 @@ describe("borderColor theme", () => {
 
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `html {
-          --color-border-a: 255 255 255;
+          --color-border-a: 255, 255, 255;
         }`.replace(/\n|\s|\t/g, "")
         );
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `${expectedSelector} {
-          --color-border-a: 0 0 0;
+          --color-border-a: 0, 0, 0;
         }`.replace(/\n|\s|\t/g, "")
         );
       });

--- a/tests/color.test.js
+++ b/tests/color.test.js
@@ -1,5 +1,5 @@
 const withModeAwareColors = require("../src/index");
-const postcss = require("postcss");
+const postcss = require("postcss", { async: true });
 
 describe("color theme", () => {
   it("Flattens color map and adds mode aware color", () => {
@@ -11,6 +11,18 @@ describe("color theme", () => {
               light: "#ffffff",
               dark: "#000000",
             },
+            b: {
+              light: 'rgb(255, 255, 255)',
+              dark: 'rgb(0, 0, 0)',
+            },
+            c: {
+              light: '#ffffff33',
+              dark: '#00000033',
+            },
+            d: {
+              light: 'rgba(255, 255, 255, 0.2)',
+              dark: 'rgba(0, 0, 0, 0.2)',
+            },
           },
         },
       })
@@ -18,9 +30,18 @@ describe("color theme", () => {
       expect.objectContaining({
         theme: {
           colors: {
-            a: "rgb(var(--color-a) / <alpha-value>)",
+            a: "rgba(var(--color-a))",
             "a-light": "#ffffff",
             "a-dark": "#000000",
+            b: "rgba(var(--color-b))",
+            "b-light": "rgb(255, 255, 255)",
+            "b-dark": "rgb(0, 0, 0)",
+            c: "rgba(var(--color-c))",
+            "c-light": "#ffffff33",
+            "c-dark": "#00000033",
+            d: "rgba(var(--color-d))",
+            "d-light": "rgba(255, 255, 255, 0.2)",
+            "d-dark": "rgba(0, 0, 0, 0.2)",
           },
         },
       })
@@ -38,6 +59,18 @@ describe("color theme", () => {
                   light: "#ffffff",
                   dark: "#000000",
                 },
+                b: {
+                  light: 'rgb(255, 255, 255)',
+                  dark: 'rgb(0, 0, 0)',
+                },
+                c: {
+                  light: '#ffffff33',
+                  dark: '#00000033',
+                },
+                d: {
+                  light: 'rgba(255, 255, 255, 0.2)',
+                  dark: 'rgba(0, 0, 0, 0.2)',
+                },
               },
             },
           },
@@ -47,9 +80,18 @@ describe("color theme", () => {
           theme: {
             extend: {
               colors: {
-                a: "rgb(var(--color-a) / <alpha-value>)",
+                a: "rgba(var(--color-a))",
                 "a-light": "#ffffff",
                 "a-dark": "#000000",
+                b: "rgba(var(--color-b))",
+                "b-light": "rgb(255, 255, 255)",
+                "b-dark": "rgb(0, 0, 0)",
+                c: "rgba(var(--color-c))",
+                "c-light": "#ffffff33",
+                "c-dark": "#00000033",
+                d: "rgba(var(--color-d))",
+                "d-light": "rgba(255, 255, 255, 0.2)",
+                "d-dark": "rgba(0, 0, 0, 0.2)",
               },
             },
           },
@@ -74,7 +116,7 @@ describe("color theme", () => {
           darkMode: darkModeConfig,
           content: [
             {
-              raw: "bg-a text-a/50 dark something custom-selector",
+              raw: "bg-a text-a/50 dark something custom-selector bg-b text-b/50 bg-c text-c/50 bg-d text-d/50",
             },
           ],
           theme: {
@@ -82,6 +124,18 @@ describe("color theme", () => {
               a: {
                 light: "#ffffff",
                 dark: "#000000",
+              },
+              b: {
+                light: 'rgb(255, 255, 255)',
+                dark: 'rgb(0, 0, 0)',
+              },
+              c: {
+                light: '#ffffff33',
+                dark: '#00000033',
+              },
+              d: {
+                light: 'rgba(255, 255, 255, 0.2)',
+                dark: 'rgba(0, 0, 0, 0.2)',
               },
             },
           },
@@ -93,14 +147,31 @@ describe("color theme", () => {
 
         expect(utilitiesCSS.replace(/\n|\s|\t/g, "")).toBe(
           `
-      .bg-a {
-        --tw-bg-opacity: 1;
-        background-color: rgb(var(--color-a) / var(--tw-bg-opacity))
-      }
-        .text-a\\/50 {
-        color: rgb(var(--color-a) / 0.5)
-      }
-      `.replace(/\n|\s|\t/g, "")
+            .bg-a {
+              background-color: rgba(var(--color-a))
+            }
+            .bg-b {
+              background-color: rgba(var(--color-b))
+            }
+            .bg-c {
+              background-color: rgba(var(--color-c))
+            }
+            .bg-d {
+              background-color: rgba(var(--color-d))
+            }
+            .text-a\\/50 {
+              color: rgba(var(--color-a), 0.5)
+            }
+            .text-b\\/50 {
+              color: rgba(var(--color-b), 0.5)
+            }
+            .text-c\\/50 {
+              color: rgba(var(--color-c), 0.5)
+            }
+            .text-d\\/50 {
+              color: rgba(var(--color-d), 0.5)
+            }
+          `.replace(/\n|\s|\t/g, "")
         );
 
         let baseCSS = postcss([require("tailwindcss")(config)]).process(
@@ -109,12 +180,18 @@ describe("color theme", () => {
 
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `html {
-          --color-a: 255 255 255;
+          --color-a: 255, 255, 255;
+          --color-b: 255, 255, 255;
+          --color-c: 255, 255, 255, 0.2;
+          --color-d: 255, 255, 255, 0.2;
         }`.replace(/\n|\s|\t/g, "")
         );
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `${expectedSelector} {
-          --color-a: 0 0 0;
+          --color-a: 0, 0, 0;
+          --color-b: 0, 0, 0;
+          --color-c: 0, 0, 0, 0.2;
+          --color-d: 0, 0, 0, 0.2;
         }`.replace(/\n|\s|\t/g, "")
         );
       });

--- a/tests/color.test.js
+++ b/tests/color.test.js
@@ -30,16 +30,16 @@ describe("color theme", () => {
       expect.objectContaining({
         theme: {
           colors: {
-            a: "rgba(var(--color-a))",
+            a: "rgb(var(--color-a) / calc(var(--opacity-a, 1) * <alpha-value>))",
             "a-light": "#ffffff",
             "a-dark": "#000000",
-            b: "rgba(var(--color-b))",
+            b: "rgb(var(--color-b) / calc(var(--opacity-b, 1) * <alpha-value>))",
             "b-light": "rgb(255, 255, 255)",
             "b-dark": "rgb(0, 0, 0)",
-            c: "rgba(var(--color-c))",
+            c: "rgb(var(--color-c) / calc(var(--opacity-c, 1) * <alpha-value>))",
             "c-light": "#ffffff33",
             "c-dark": "#00000033",
-            d: "rgba(var(--color-d))",
+            d: "rgb(var(--color-d) / calc(var(--opacity-d, 1) * <alpha-value>))",
             "d-light": "rgba(255, 255, 255, 0.2)",
             "d-dark": "rgba(0, 0, 0, 0.2)",
           },
@@ -80,16 +80,16 @@ describe("color theme", () => {
           theme: {
             extend: {
               colors: {
-                a: "rgba(var(--color-a))",
+                a: "rgb(var(--color-a) / calc(var(--opacity-a, 1) * <alpha-value>))",
                 "a-light": "#ffffff",
                 "a-dark": "#000000",
-                b: "rgba(var(--color-b))",
+                b: "rgb(var(--color-b) / calc(var(--opacity-b, 1) * <alpha-value>))",
                 "b-light": "rgb(255, 255, 255)",
                 "b-dark": "rgb(0, 0, 0)",
-                c: "rgba(var(--color-c))",
+                c: "rgb(var(--color-c) / calc(var(--opacity-c, 1) * <alpha-value>))",
                 "c-light": "#ffffff33",
                 "c-dark": "#00000033",
-                d: "rgba(var(--color-d))",
+                d: "rgb(var(--color-d) / calc(var(--opacity-d, 1) * <alpha-value>))",
                 "d-light": "rgba(255, 255, 255, 0.2)",
                 "d-dark": "rgba(0, 0, 0, 0.2)",
               },
@@ -148,28 +148,32 @@ describe("color theme", () => {
         expect(utilitiesCSS.replace(/\n|\s|\t/g, "")).toBe(
           `
             .bg-a {
-              background-color: rgba(var(--color-a))
+              --tw-bg-opacity: 1;
+              background-color: rgb(var(--color-a) / calc(var(--opacity-a, 1) * var(--tw-bg-opacity)))
             }
             .bg-b {
-              background-color: rgba(var(--color-b))
+              --tw-bg-opacity: 1;
+              background-color: rgb(var(--color-b) / calc(var(--opacity-b, 1) * var(--tw-bg-opacity)))
             }
             .bg-c {
-              background-color: rgba(var(--color-c))
+              --tw-bg-opacity: 1;
+              background-color: rgb(var(--color-c) / calc(var(--opacity-c, 1) * var(--tw-bg-opacity)))
             }
             .bg-d {
-              background-color: rgba(var(--color-d))
+              --tw-bg-opacity: 1;
+              background-color: rgb(var(--color-d) / calc(var(--opacity-d, 1) * var(--tw-bg-opacity)))
             }
             .text-a\\/50 {
-              color: rgba(var(--color-a), 0.5)
+              color: rgb(var(--color-a) / calc(var(--opacity-a, 1) * 0.5))
             }
             .text-b\\/50 {
-              color: rgba(var(--color-b), 0.5)
+              color: rgb(var(--color-b) / calc(var(--opacity-b, 1) * 0.5))
             }
             .text-c\\/50 {
-              color: rgba(var(--color-c), 0.5)
+              color: rgb(var(--color-c) / calc(var(--opacity-c, 1) * 0.5))
             }
             .text-d\\/50 {
-              color: rgba(var(--color-d), 0.5)
+              color: rgb(var(--color-d) / calc(var(--opacity-d, 1) * 0.5))
             }
           `.replace(/\n|\s|\t/g, "")
         );
@@ -180,18 +184,22 @@ describe("color theme", () => {
 
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `html {
-          --color-a: 255, 255, 255;
-          --color-b: 255, 255, 255;
-          --color-c: 255, 255, 255, 0.2;
-          --color-d: 255, 255, 255, 0.2;
+          --color-a: 255 255 255;
+          --color-b: 255 255 255;
+          --color-c: 255 255 255;
+          --opacity-c: 20%;
+          --color-d: 255 255 255;
+          --opacity-d: 20%;
         }`.replace(/\n|\s|\t/g, "")
         );
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `${expectedSelector} {
-          --color-a: 0, 0, 0;
-          --color-b: 0, 0, 0;
-          --color-c: 0, 0, 0, 0.2;
-          --color-d: 0, 0, 0, 0.2;
+          --color-a: 0 0 0;
+          --color-b: 0 0 0;
+          --color-c: 0 0 0;
+          --opacity-c: 20%;
+          --color-d: 0 0 0;
+          --opacity-d: 20%;
         }`.replace(/\n|\s|\t/g, "")
         );
       });

--- a/tests/complex.test.js
+++ b/tests/complex.test.js
@@ -36,22 +36,22 @@ describe("Complex test", () => {
       expect.objectContaining({
         theme: {
           colors: {
-            a: "rgb(var(--color-a) / <alpha-value>)",
+            a: "rgba(var(--color-a))",
             "a-light": "#fcfcfc",
             "a-dark": "#030303",
           },
           borderColor: {
-            a: "rgb(var(--color-border-a) / <alpha-value>)",
+            a: "rgba(var(--color-border-a))",
             "a-light": "#ffffff",
             "a-dark": "#000000",
           },
           textColor: {
-            a: "rgb(var(--color-text-a) / <alpha-value>)",
+            a: "rgba(var(--color-text-a))",
             "a-light": "#fefefe",
             "a-dark": "#010101",
           },
           backgroundColor: {
-            a: "rgb(var(--color-background-a) / <alpha-value>)",
+            a: "rgba(var(--color-background-a))",
             "a-light": "#fdfdfd",
             "a-dark": "#020202",
           },
@@ -114,18 +114,16 @@ describe("Complex test", () => {
         expect(utilitiesCSS.replace(/\n|\s|\t/g, "")).toBe(
           `
       .border-a {
-        --tw-border-opacity: 1;
-        border-color: rgb(var(--color-border-a) / var(--tw-border-opacity))
+        border-color: rgba(var(--color-border-a))
       }
       .bg-a {
-        --tw-bg-opacity: 1;
-        background-color: rgb(var(--color-background-a) / var(--tw-bg-opacity))
+        background-color: rgba(var(--color-background-a))
       }
       .text-a\\/50 {
-        color: rgb(var(--color-text-a) / 0.5)
+        color: rgba(var(--color-text-a), 0.5)
       }
       .outline-a\\/20 {
-        outline-color: rgb(var(--color-a) / 0.2)
+        outline-color: rgba(var(--color-a), 0.2)
       }
       `.replace(/\n|\s|\t/g, "")
         );
@@ -136,18 +134,18 @@ describe("Complex test", () => {
 
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `html {
-          --color-a: 252 252 252;
-          --color-text-a: 254 254 254;
-          --color-background-a: 253 253 253;
-          --color-border-a: 255 255 255;
+          --color-a: 252, 252, 252;
+          --color-text-a: 254, 254, 254;
+          --color-background-a: 253, 253, 253;
+          --color-border-a: 255, 255, 255;
         }`.replace(/\n|\s|\t/g, "")
         );
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `${expectedSelector} {
-          --color-a: 3 3 3;
-          --color-text-a: 1 1 1;
-          --color-background-a: 2 2 2;
-          --color-border-a: 0 0 0;
+          --color-a: 3, 3, 3;
+          --color-text-a: 1, 1, 1;
+          --color-background-a: 2, 2, 2;
+          --color-border-a: 0, 0, 0;
         }`.replace(/\n|\s|\t/g, "")
         );
       });

--- a/tests/complex.test.js
+++ b/tests/complex.test.js
@@ -36,22 +36,22 @@ describe("Complex test", () => {
       expect.objectContaining({
         theme: {
           colors: {
-            a: "rgba(var(--color-a))",
+            a: "rgb(var(--color-a) / calc(var(--opacity-a, 1) * <alpha-value>))",
             "a-light": "#fcfcfc",
             "a-dark": "#030303",
           },
           borderColor: {
-            a: "rgba(var(--color-border-a))",
+            a: "rgb(var(--color-border-a) / calc(var(--opacity-border-a, 1) * <alpha-value>))",
             "a-light": "#ffffff",
             "a-dark": "#000000",
           },
           textColor: {
-            a: "rgba(var(--color-text-a))",
+            a: "rgb(var(--color-text-a) / calc(var(--opacity-text-a, 1) * <alpha-value>))",
             "a-light": "#fefefe",
             "a-dark": "#010101",
           },
           backgroundColor: {
-            a: "rgba(var(--color-background-a))",
+            a: "rgb(var(--color-background-a) / calc(var(--opacity-background-a, 1) * <alpha-value>))",
             "a-light": "#fdfdfd",
             "a-dark": "#020202",
           },
@@ -114,16 +114,18 @@ describe("Complex test", () => {
         expect(utilitiesCSS.replace(/\n|\s|\t/g, "")).toBe(
           `
       .border-a {
-        border-color: rgba(var(--color-border-a))
+        --tw-border-opacity: 1;
+        border-color: rgb(var(--color-border-a) / calc(var(--opacity-border-a, 1) * var(--tw-border-opacity)))
       }
       .bg-a {
-        background-color: rgba(var(--color-background-a))
+        --tw-bg-opacity: 1;
+        background-color: rgb(var(--color-background-a) / calc(var(--opacity-background-a, 1) * var(--tw-bg-opacity)))
       }
       .text-a\\/50 {
-        color: rgba(var(--color-text-a), 0.5)
+        color: rgb(var(--color-text-a) / calc(var(--opacity-text-a, 1) * 0.5))
       }
       .outline-a\\/20 {
-        outline-color: rgba(var(--color-a), 0.2)
+        outline-color: rgb(var(--color-a) / calc(var(--opacity-a, 1) * 0.2))
       }
       `.replace(/\n|\s|\t/g, "")
         );
@@ -134,18 +136,18 @@ describe("Complex test", () => {
 
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `html {
-          --color-a: 252, 252, 252;
-          --color-text-a: 254, 254, 254;
-          --color-background-a: 253, 253, 253;
-          --color-border-a: 255, 255, 255;
+          --color-a: 252 252 252;
+          --color-text-a: 254 254 254;
+          --color-background-a: 253 253 253;
+          --color-border-a: 255 255 255;
         }`.replace(/\n|\s|\t/g, "")
         );
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `${expectedSelector} {
-          --color-a: 3, 3, 3;
-          --color-text-a: 1, 1, 1;
-          --color-background-a: 2, 2, 2;
-          --color-border-a: 0, 0, 0;
+          --color-a: 3 3 3;
+          --color-text-a: 1 1 1;
+          --color-background-a: 2 2 2;
+          --color-border-a: 0 0 0;
         }`.replace(/\n|\s|\t/g, "")
         );
       });

--- a/tests/comprehensiveThemeGeneration.test.js
+++ b/tests/comprehensiveThemeGeneration.test.js
@@ -19,7 +19,7 @@ describe("With nested color syntax", () => {
       expect.objectContaining({
         theme: {
           colors: {
-            "a-b": "rgb(var(--color-a-b) / <alpha-value>)",
+            "a-b": "rgba(var(--color-a-b))",
             "a-b-light": "#ffffff",
             "a-b-dark": "#000000",
           },
@@ -52,7 +52,7 @@ describe("With -light- and -dark- segments in the middle", () => {
       expect.objectContaining({
         theme: {
           colors: {
-            "a-b-c": "rgb(var(--color-a-b-c) / <alpha-value>)",
+            "a-b-c": "rgba(var(--color-a-b-c))",
             "a-b-light-c": "#ffffff",
             "a-b-dark-c": "#000000",
           },
@@ -81,7 +81,7 @@ describe("With light- and dark- segments at the start", () => {
       expect.objectContaining({
         theme: {
           colors: {
-            a: "rgb(var(--color-a) / <alpha-value>)",
+            a: "rgba(var(--color-a))",
             "light-a": "#ffffff",
             "dark-a": "#000000",
           },
@@ -111,7 +111,7 @@ describe("With custom light and dark ids", () => {
       expect.objectContaining({
         theme: {
           colors: {
-            a: "rgb(var(--color-a) / <alpha-value>)",
+            a: "rgba(var(--color-a))",
             "a-claro": "#ffffff",
             "a-oscuro": "#000000",
           },

--- a/tests/comprehensiveThemeGeneration.test.js
+++ b/tests/comprehensiveThemeGeneration.test.js
@@ -19,7 +19,7 @@ describe("With nested color syntax", () => {
       expect.objectContaining({
         theme: {
           colors: {
-            "a-b": "rgba(var(--color-a-b))",
+            "a-b": "rgb(var(--color-a-b) / calc(var(--opacity-a-b, 1) * <alpha-value>))",
             "a-b-light": "#ffffff",
             "a-b-dark": "#000000",
           },
@@ -52,7 +52,7 @@ describe("With -light- and -dark- segments in the middle", () => {
       expect.objectContaining({
         theme: {
           colors: {
-            "a-b-c": "rgba(var(--color-a-b-c))",
+            "a-b-c": "rgb(var(--color-a-b-c) / calc(var(--opacity-a-b-c, 1) * <alpha-value>))",
             "a-b-light-c": "#ffffff",
             "a-b-dark-c": "#000000",
           },
@@ -81,7 +81,7 @@ describe("With light- and dark- segments at the start", () => {
       expect.objectContaining({
         theme: {
           colors: {
-            a: "rgba(var(--color-a))",
+            a: "rgb(var(--color-a) / calc(var(--opacity-a, 1) * <alpha-value>))",
             "light-a": "#ffffff",
             "dark-a": "#000000",
           },
@@ -111,7 +111,7 @@ describe("With custom light and dark ids", () => {
       expect.objectContaining({
         theme: {
           colors: {
-            a: "rgba(var(--color-a))",
+            a: "rgb(var(--color-a) / calc(var(--opacity-a, 1) * <alpha-value>))",
             "a-claro": "#ffffff",
             "a-oscuro": "#000000",
           },

--- a/tests/outlineColor.test.js
+++ b/tests/outlineColor.test.js
@@ -18,7 +18,7 @@ describe("outlineColor theme", () => {
       expect.objectContaining({
         theme: {
           outlineColor: {
-            a: "rgb(var(--color-outline-a) / <alpha-value>)",
+            a: "rgba(var(--color-outline-a))",
             "a-light": "#ffffff",
             "a-dark": "#000000",
           },
@@ -47,7 +47,7 @@ describe("outlineColor theme", () => {
           theme: {
             extend: {
               outlineColor: {
-                a: "rgb(var(--color-outline-a) / <alpha-value>)",
+                a: "rgba(var(--color-outline-a))",
                 "a-light": "#ffffff",
                 "a-dark": "#000000",
               },
@@ -94,7 +94,7 @@ describe("outlineColor theme", () => {
         expect(utilitiesCSS.replace(/\n|\s|\t/g, "")).toBe(
           `
           .outline-a\\/50 {
-            outline-color: rgb(var(--color-outline-a) / 0.5)
+            outline-color: rgba(var(--color-outline-a), 0.5)
           }
           `.replace(/\n|\s|\t/g, "")
         );
@@ -105,12 +105,12 @@ describe("outlineColor theme", () => {
 
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `html {
-          --color-outline-a: 255 255 255;
+          --color-outline-a: 255, 255, 255;
         }`.replace(/\n|\s|\t/g, "")
         );
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `${expectedSelector} {
-          --color-outline-a: 0 0 0;
+          --color-outline-a: 0, 0, 0;
         }`.replace(/\n|\s|\t/g, "")
         );
       });

--- a/tests/outlineColor.test.js
+++ b/tests/outlineColor.test.js
@@ -18,7 +18,7 @@ describe("outlineColor theme", () => {
       expect.objectContaining({
         theme: {
           outlineColor: {
-            a: "rgba(var(--color-outline-a))",
+            a: "rgb(var(--color-outline-a) / calc(var(--opacity-outline-a, 1) * <alpha-value>))",
             "a-light": "#ffffff",
             "a-dark": "#000000",
           },
@@ -47,7 +47,7 @@ describe("outlineColor theme", () => {
           theme: {
             extend: {
               outlineColor: {
-                a: "rgba(var(--color-outline-a))",
+                a: "rgb(var(--color-outline-a) / calc(var(--opacity-outline-a, 1) * <alpha-value>))",
                 "a-light": "#ffffff",
                 "a-dark": "#000000",
               },
@@ -74,7 +74,7 @@ describe("outlineColor theme", () => {
           darkMode: darkModeConfig,
           content: [
             {
-              raw: "bg-a/50 text-a border-a outline-a/50 dark something custom-selector",
+              raw: "bg-a/50 text-a border-a outline-b/50 outline-a dark something custom-selector",
             },
           ],
           theme: {
@@ -82,6 +82,10 @@ describe("outlineColor theme", () => {
               a: {
                 light: "#ffffff",
                 dark: "#000000",
+              },
+              b: {
+                light: "rgba(255, 255, 255, 0.2)",
+                dark: "rgba(0, 0, 0, 0.2)",
               },
             },
           },
@@ -93,8 +97,11 @@ describe("outlineColor theme", () => {
 
         expect(utilitiesCSS.replace(/\n|\s|\t/g, "")).toBe(
           `
-          .outline-a\\/50 {
-            outline-color: rgba(var(--color-outline-a), 0.5)
+          .outline-a {
+            outline-color: rgb(var(--color-outline-a) / calc(var(--opacity-outline-a, 1) * 1))
+          }
+          .outline-b\\/50 {
+            outline-color: rgb(var(--color-outline-b) / calc(var(--opacity-outline-b, 1) * 0.5))
           }
           `.replace(/\n|\s|\t/g, "")
         );
@@ -105,12 +112,16 @@ describe("outlineColor theme", () => {
 
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `html {
-          --color-outline-a: 255, 255, 255;
+          --color-outline-a: 255 255 255;
+          --color-outline-b: 255 255 255;
+          --opacity-outline-b: 20%;
         }`.replace(/\n|\s|\t/g, "")
         );
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `${expectedSelector} {
-          --color-outline-a: 0, 0, 0;
+          --color-outline-a: 0 0 0;
+          --color-outline-b: 0 0 0;
+          --opacity-outline-b: 20%;
         }`.replace(/\n|\s|\t/g, "")
         );
       });

--- a/tests/textColor.test.js
+++ b/tests/textColor.test.js
@@ -18,7 +18,7 @@ describe("textColor theme", () => {
       expect.objectContaining({
         theme: {
           textColor: {
-            a: "rgb(var(--color-text-a) / <alpha-value>)",
+            a: "rgba(var(--color-text-a))",
             "a-light": "#ffffff",
             "a-dark": "#000000",
           },
@@ -47,7 +47,7 @@ describe("textColor theme", () => {
           theme: {
             extend: {
               textColor: {
-                a: "rgb(var(--color-text-a) / <alpha-value>)",
+                a: "rgba(var(--color-text-a))",
                 "a-light": "#ffffff",
                 "a-dark": "#000000",
               },
@@ -94,7 +94,7 @@ describe("textColor theme", () => {
         expect(utilitiesCSS.replace(/\n|\s|\t/g, "")).toBe(
           `
           .text-a\\/50 {
-            color: rgb(var(--color-text-a) / 0.5)
+            color: rgba(var(--color-text-a), 0.5)
           }
           `.replace(/\n|\s|\t/g, "")
         );
@@ -105,12 +105,12 @@ describe("textColor theme", () => {
 
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `html {
-          --color-text-a: 255 255 255;
+          --color-text-a: 255, 255, 255;
         }`.replace(/\n|\s|\t/g, "")
         );
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `${expectedSelector} {
-          --color-text-a: 0 0 0;
+          --color-text-a: 0, 0, 0;
         }`.replace(/\n|\s|\t/g, "")
         );
       });

--- a/tests/textColor.test.js
+++ b/tests/textColor.test.js
@@ -18,7 +18,7 @@ describe("textColor theme", () => {
       expect.objectContaining({
         theme: {
           textColor: {
-            a: "rgba(var(--color-text-a))",
+            a: "rgb(var(--color-text-a) / calc(var(--opacity-text-a, 1) * <alpha-value>))",
             "a-light": "#ffffff",
             "a-dark": "#000000",
           },
@@ -47,7 +47,7 @@ describe("textColor theme", () => {
           theme: {
             extend: {
               textColor: {
-                a: "rgba(var(--color-text-a))",
+                a: "rgb(var(--color-text-a) / calc(var(--opacity-text-a, 1) * <alpha-value>))",
                 "a-light": "#ffffff",
                 "a-dark": "#000000",
               },
@@ -94,7 +94,7 @@ describe("textColor theme", () => {
         expect(utilitiesCSS.replace(/\n|\s|\t/g, "")).toBe(
           `
           .text-a\\/50 {
-            color: rgba(var(--color-text-a), 0.5)
+            color: rgb(var(--color-text-a) / calc(var(--opacity-text-a, 1) * 0.5))
           }
           `.replace(/\n|\s|\t/g, "")
         );
@@ -105,12 +105,12 @@ describe("textColor theme", () => {
 
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `html {
-          --color-text-a: 255, 255, 255;
+          --color-text-a: 255 255 255;
         }`.replace(/\n|\s|\t/g, "")
         );
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `${expectedSelector} {
-          --color-text-a: 0, 0, 0;
+          --color-text-a: 0 0 0;
         }`.replace(/\n|\s|\t/g, "")
         );
       });


### PR DESCRIPTION
This PR aims to add support for using colors with opacities in tailwind.

Changes:
* Updated to v1.4.0
* Generated CSS classes now use `rgba(var(--color-a))` instead of `rgb(var(--color-a) / <alpha-value>`
* Generated CSS variables are now comma-separated instead of space-separated. This is the only way it would work, but it shouldn't affect anything.
* Added new tests in `colors.test.js` for the following color formats: rgb, rgba, and 8-character hex codes
* Updated all tests to ensure the new formats are generating correctly
* Updated tailwind version to `3.0.0 - 3.3.2` to prevent a PostCSS bug that was introduced in [`3.3.3`](https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.3.3) when they migrated to an async PostCSS plugin version.
* Added a short description of the feature to README.md