### PR TITLE
Support color opacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Any pair of colors `X-light` and `X-dark` will yield a new color `X` that automa
 
 - You can also use the plugin with scoped tailwind color configuration such as `textColor`, `backgroundColor`, `borderColor` or `outlineColor`.
 
+- To hardcode opacity values in your tailwind config, you can use rgba `rgba(255, 255, 255, 0.2)` or hex `#ffffff33`
+
 ## Options
 
 If for some reason `-light` and `-dark` are not right for your use case, you can pass an options object as a second parameter and customize the suffixes. Just replace `"light"` and `"dark"` with any other string.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Any pair of colors `X-light` and `X-dark` will yield a new color `X` that automa
 
 - You can also use the plugin with scoped tailwind color configuration such as `textColor`, `backgroundColor`, `borderColor` or `outlineColor`.
 
-- To hardcode opacity values in your tailwind config, you can use rgba `rgba(255, 255, 255, 0.2)` or hex `#ffffff33`
+- You can set default opacity to colors with hex or rgba syntax.
 
 ## Options
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-mode-aware-colors",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "TailwindCSS Plugin to generate dynamic colors that will automatically switch between light and dark mode variants.",
   "main": "src/index.js",
   "license": "MIT",
@@ -26,7 +26,7 @@
   "devDependencies": {
     "jest": "^27.2.4",
     "postcss": "^8.2.4",
-    "tailwindcss": "^3.0.0"
+    "tailwindcss": "3.1.0 - 3.3.2"
   },
   "author": "Javier Morales"
 }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
   ],
   "devDependencies": {
     "jest": "^27.2.4",
-    "postcss": "^8.2.4",
-    "tailwindcss": "3.1.0 - 3.3.2"
+    "postcss": "^8.2.4"
   },
   "author": "Javier Morales"
 }

--- a/src/index.js
+++ b/src/index.js
@@ -41,20 +41,41 @@ const processColors = (
         if (colors[modeAwareColorName]) {
           throw `withModeAwareColors plugin error: adding the '${modeAwareColorName}' mode-aware color would overwrite an existing color.`;
         } else {
-          const varName = `--color-${
+          const colorName = `--color-${
             variablePrefix ? `${variablePrefix}-` : ""
           }${modeAwareColorName}`;
-          colors[modeAwareColorName] = `rgba(var(${varName}))`;
 
-          const lightStyle = Color(lightColor).rgb().array().join(", ");
-          const darkStyle = Color(darkColor).rgb().array().join(", ");
+          const opacityName = `--opacity-${
+            variablePrefix ? `${variablePrefix}-` : ""
+          }${modeAwareColorName}`;
 
-          styles.html[varName] = lightStyle;
+          colors[modeAwareColorName] = `rgb(var(${colorName}) / calc(var(${opacityName}, 1) * <alpha-value>))`;
+
+          const lightArray = Color(lightColor).rgb().array();
+          const lightColorStyle = lightArray.slice(0, 3).join(" ");
+          const lightOpacityStyle = lightArray.length > 3 ? `${lightArray[3] * 100}%` : undefined;
+          
+          const darkArray = Color(darkColor).rgb().array();
+          const darkColorStyle = darkArray.slice(0, 3).join(" ");
+          const darkOpacityStyle = darkArray.length > 3 ? `${darkArray[3] * 100}%` : undefined;
+
+          styles.html[colorName] = lightColorStyle;
+          if (lightOpacityStyle) {
+            styles.html[opacityName] = lightOpacityStyle;
+          }
+
           if (usesMediaStrategy) {
-            styles["@media (prefers-color-scheme: dark)"].html[varName] =
-              darkStyle;
+            styles["@media (prefers-color-scheme: dark)"].html[colorName] =
+              darkColorStyle;
+            if (darkOpacityStyle) {
+              styles["@media (prefers-color-scheme: dark)"].html[opacityName] =
+                darkOpacityStyle;
+            }
           } else {
-            styles[darkSelector][varName] = darkStyle;
+            styles[darkSelector][colorName] = darkColorStyle;
+            if (darkOpacityStyle) {
+              styles[darkSelector][opacityName] = darkOpacityStyle;
+            }
           }
         }
       }

--- a/src/index.js
+++ b/src/index.js
@@ -44,10 +44,10 @@ const processColors = (
           const varName = `--color-${
             variablePrefix ? `${variablePrefix}-` : ""
           }${modeAwareColorName}`;
-          colors[modeAwareColorName] = `rgb(var(${varName}) / <alpha-value>)`;
+          colors[modeAwareColorName] = `rgba(var(${varName}))`;
 
-          const lightStyle = Color(lightColor).rgb().array().join(" ");
-          const darkStyle = Color(darkColor).rgb().array().join(" ");
+          const lightStyle = Color(lightColor).rgb().array().join(", ");
+          const darkStyle = Color(darkColor).rgb().array().join(", ");
 
           styles.html[varName] = lightStyle;
           if (usesMediaStrategy) {

--- a/src/index.js
+++ b/src/index.js
@@ -41,40 +41,51 @@ const processColors = (
         if (colors[modeAwareColorName]) {
           throw `withModeAwareColors plugin error: adding the '${modeAwareColorName}' mode-aware color would overwrite an existing color.`;
         } else {
-          const colorName = `--color-${
-            variablePrefix ? `${variablePrefix}-` : ""
-          }${modeAwareColorName}`;
-
-          const opacityName = `--opacity-${
-            variablePrefix ? `${variablePrefix}-` : ""
-          }${modeAwareColorName}`;
-
-          colors[modeAwareColorName] = `rgb(var(${colorName}) / calc(var(${opacityName}, 1) * <alpha-value>))`;
-
           const lightArray = Color(lightColor).rgb().array();
           const lightColorStyle = lightArray.slice(0, 3).join(" ");
-          const lightOpacityStyle = lightArray.length > 3 ? `${lightArray[3] * 100}%` : undefined;
-          
+          const lightOpacityStyle =
+            lightArray.length > 3 ? `${lightArray[3] * 100}%` : undefined;
+
           const darkArray = Color(darkColor).rgb().array();
           const darkColorStyle = darkArray.slice(0, 3).join(" ");
-          const darkOpacityStyle = darkArray.length > 3 ? `${darkArray[3] * 100}%` : undefined;
+          const darkOpacityStyle =
+            darkArray.length > 3 ? `${darkArray[3] * 100}%` : undefined;
 
-          styles.html[colorName] = lightColorStyle;
+          const colorVariable = `--color-${
+            variablePrefix ? `${variablePrefix}-` : ""
+          }${modeAwareColorName}`;
+
+          const opacityVariable = `--opacity-${
+            variablePrefix ? `${variablePrefix}-` : ""
+          }${modeAwareColorName}`;
+
+          colors[modeAwareColorName] = ({ opacityValue }) =>
+            `rgb(var(${colorVariable}) / ${
+              opacityValue
+                ? typeof opacityValue === "string" &&
+                  opacityValue.startsWith("var(")
+                  ? `var(${opacityVariable}, ${opacityValue})`
+                  : opacityValue
+                : `var(${opacityVariable}, 1)`
+            })`;
+
+          styles.html[colorVariable] = lightColorStyle;
           if (lightOpacityStyle) {
-            styles.html[opacityName] = lightOpacityStyle;
+            styles.html[opacityVariable] = lightOpacityStyle;
           }
 
           if (usesMediaStrategy) {
-            styles["@media (prefers-color-scheme: dark)"].html[colorName] =
+            styles["@media (prefers-color-scheme: dark)"].html[colorVariable] =
               darkColorStyle;
             if (darkOpacityStyle) {
-              styles["@media (prefers-color-scheme: dark)"].html[opacityName] =
-                darkOpacityStyle;
+              styles["@media (prefers-color-scheme: dark)"].html[
+                opacityVariable
+              ] = darkOpacityStyle;
             }
           } else {
-            styles[darkSelector][colorName] = darkColorStyle;
+            styles[darkSelector][colorVariable] = darkColorStyle;
             if (darkOpacityStyle) {
-              styles[darkSelector][opacityName] = darkOpacityStyle;
+              styles[darkSelector][opacityVariable] = darkOpacityStyle;
             }
           }
         }

--- a/tests/backgroundColor.test.js
+++ b/tests/backgroundColor.test.js
@@ -2,23 +2,23 @@ const withModeAwareColors = require("../src/index");
 const postcss = require("postcss");
 
 describe("backgroundColor theme", () => {
-  it("Flattens color map and adds mode aware color", () => {
-    expect(
-      withModeAwareColors({
-        theme: {
-          backgroundColor: {
-            a: {
-              light: "#ffffff",
-              dark: "#000000",
-            },
-          },
+  const config = withModeAwareColors({
+    theme: {
+      backgroundColor: {
+        a: {
+          light: "#ffffff",
+          dark: "#000000",
         },
-      })
-    ).toEqual(
+      },
+    },
+  });
+
+  it("Flattens color map and adds mode aware color", () => {
+    expect(config).toEqual(
       expect.objectContaining({
         theme: {
           backgroundColor: {
-            a: "rgb(var(--color-background-a) / calc(var(--opacity-background-a, 1) * <alpha-value>))",
+            a: expect.any(Function),
             "a-light": "#ffffff",
             "a-dark": "#000000",
           },
@@ -27,33 +27,59 @@ describe("backgroundColor theme", () => {
     );
   });
 
+  it("Defines mode aware color as a function based on opacity", () => {
+    const a = config.theme.backgroundColor.a;
+    expect(a({})).toEqual(
+      "rgb(var(--color-background-a) / var(--opacity-background-a, 1))"
+    );
+    expect(a({ opacityValue: 0.4 })).toEqual(
+      "rgb(var(--color-background-a) / 0.4)"
+    );
+    expect(a({ opacityValue: "var(--tw-bg-opacity)" })).toEqual(
+      "rgb(var(--color-background-a) / var(--opacity-background-a, var(--tw-bg-opacity)))"
+    );
+  });
+
   describe("extend", () => {
-    it("Flattens extend color map and adds mode aware color", () => {
-      expect(
-        withModeAwareColors({
-          theme: {
-            extend: {
-              backgroundColor: {
-                a: {
-                  light: "#ffffff",
-                  dark: "#000000",
-                },
-              },
+    const config = withModeAwareColors({
+      theme: {
+        extend: {
+          backgroundColor: {
+            a: {
+              light: "#ffffff",
+              dark: "#000000",
             },
           },
-        })
-      ).toEqual(
+        },
+      },
+    });
+
+    it("Flattens extend color map and adds mode aware color", () => {
+      expect(config).toEqual(
         expect.objectContaining({
           theme: {
             extend: {
               backgroundColor: {
-                a: "rgb(var(--color-background-a) / calc(var(--opacity-background-a, 1) * <alpha-value>))",
+                a: expect.any(Function),
                 "a-light": "#ffffff",
                 "a-dark": "#000000",
               },
             },
           },
         })
+      );
+    });
+
+    it("Defines mode aware color as a function based on opacity", () => {
+      const a = config.theme.extend.backgroundColor.a;
+      expect(a({})).toEqual(
+        "rgb(var(--color-background-a) / var(--opacity-background-a, 1))"
+      );
+      expect(a({ opacityValue: 0.4 })).toEqual(
+        "rgb(var(--color-background-a) / 0.4)"
+      );
+      expect(a({ opacityValue: "var(--tw-bg-opacity)" })).toEqual(
+        "rgb(var(--color-background-a) / var(--opacity-background-a, var(--tw-bg-opacity)))"
       );
     });
   });
@@ -94,7 +120,7 @@ describe("backgroundColor theme", () => {
         expect(utilitiesCSS.replace(/\n|\s|\t/g, "")).toBe(
           `
           .bg-a\\/50 {
-            background-color: rgb(var(--color-background-a) / calc(var(--opacity-background-a, 1) * 0.5))
+            background-color: rgb(var(--color-background-a) / 0.5)
           }
           `.replace(/\n|\s|\t/g, "")
         );

--- a/tests/backgroundColor.test.js
+++ b/tests/backgroundColor.test.js
@@ -18,7 +18,7 @@ describe("backgroundColor theme", () => {
       expect.objectContaining({
         theme: {
           backgroundColor: {
-            a: "rgba(var(--color-background-a))",
+            a: "rgb(var(--color-background-a) / calc(var(--opacity-background-a, 1) * <alpha-value>))",
             "a-light": "#ffffff",
             "a-dark": "#000000",
           },
@@ -47,7 +47,7 @@ describe("backgroundColor theme", () => {
           theme: {
             extend: {
               backgroundColor: {
-                a: "rgba(var(--color-background-a))",
+                a: "rgb(var(--color-background-a) / calc(var(--opacity-background-a, 1) * <alpha-value>))",
                 "a-light": "#ffffff",
                 "a-dark": "#000000",
               },
@@ -94,7 +94,7 @@ describe("backgroundColor theme", () => {
         expect(utilitiesCSS.replace(/\n|\s|\t/g, "")).toBe(
           `
           .bg-a\\/50 {
-            background-color: rgba(var(--color-background-a), 0.5)
+            background-color: rgb(var(--color-background-a) / calc(var(--opacity-background-a, 1) * 0.5))
           }
           `.replace(/\n|\s|\t/g, "")
         );
@@ -105,12 +105,12 @@ describe("backgroundColor theme", () => {
 
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `html {
-          --color-background-a: 255, 255, 255;
+          --color-background-a: 255 255 255;
         }`.replace(/\n|\s|\t/g, "")
         );
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `${expectedSelector} {
-          --color-background-a: 0, 0, 0;
+          --color-background-a: 0 0 0;
         }`.replace(/\n|\s|\t/g, "")
         );
       });

--- a/tests/backgroundColor.test.js
+++ b/tests/backgroundColor.test.js
@@ -18,7 +18,7 @@ describe("backgroundColor theme", () => {
       expect.objectContaining({
         theme: {
           backgroundColor: {
-            a: "rgb(var(--color-background-a) / <alpha-value>)",
+            a: "rgba(var(--color-background-a))",
             "a-light": "#ffffff",
             "a-dark": "#000000",
           },
@@ -47,7 +47,7 @@ describe("backgroundColor theme", () => {
           theme: {
             extend: {
               backgroundColor: {
-                a: "rgb(var(--color-background-a) / <alpha-value>)",
+                a: "rgba(var(--color-background-a))",
                 "a-light": "#ffffff",
                 "a-dark": "#000000",
               },
@@ -94,7 +94,7 @@ describe("backgroundColor theme", () => {
         expect(utilitiesCSS.replace(/\n|\s|\t/g, "")).toBe(
           `
           .bg-a\\/50 {
-            background-color: rgb(var(--color-background-a) / 0.5)
+            background-color: rgba(var(--color-background-a), 0.5)
           }
           `.replace(/\n|\s|\t/g, "")
         );
@@ -105,12 +105,12 @@ describe("backgroundColor theme", () => {
 
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `html {
-          --color-background-a: 255 255 255;
+          --color-background-a: 255, 255, 255;
         }`.replace(/\n|\s|\t/g, "")
         );
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `${expectedSelector} {
-          --color-background-a: 0 0 0;
+          --color-background-a: 0, 0, 0;
         }`.replace(/\n|\s|\t/g, "")
         );
       });

--- a/tests/borderColor.test.js
+++ b/tests/borderColor.test.js
@@ -2,23 +2,23 @@ const withModeAwareColors = require("../src/index");
 const postcss = require("postcss");
 
 describe("borderColor theme", () => {
-  it("Flattens color map and adds mode aware color", () => {
-    expect(
-      withModeAwareColors({
-        theme: {
-          borderColor: {
-            a: {
-              light: "#ffffff",
-              dark: "#000000",
-            },
-          },
+  const config = withModeAwareColors({
+    theme: {
+      borderColor: {
+        a: {
+          light: "#ffffff",
+          dark: "#000000",
         },
-      })
-    ).toEqual(
+      },
+    },
+  });
+
+  it("Flattens color map and adds mode aware color", () => {
+    expect(config).toEqual(
       expect.objectContaining({
         theme: {
           borderColor: {
-            a: "rgb(var(--color-border-a) / calc(var(--opacity-border-a, 1) * <alpha-value>))",
+            a: expect.any(Function),
             "a-light": "#ffffff",
             "a-dark": "#000000",
           },
@@ -27,33 +27,59 @@ describe("borderColor theme", () => {
     );
   });
 
+  it("Defines mode aware color as a function based on opacity", () => {
+    const a = config.theme.borderColor.a;
+    expect(a({})).toEqual(
+      "rgb(var(--color-border-a) / var(--opacity-border-a, 1))"
+    );
+    expect(a({ opacityValue: 0.4 })).toEqual(
+      "rgb(var(--color-border-a) / 0.4)"
+    );
+    expect(a({ opacityValue: "var(--tw-border-opacity)" })).toEqual(
+      "rgb(var(--color-border-a) / var(--opacity-border-a, var(--tw-border-opacity)))"
+    );
+  });
+
   describe("extend", () => {
-    it("Flattens extend color map and adds mode aware color", () => {
-      expect(
-        withModeAwareColors({
-          theme: {
-            extend: {
-              borderColor: {
-                a: {
-                  light: "#ffffff",
-                  dark: "#000000",
-                },
-              },
+    const config = withModeAwareColors({
+      theme: {
+        extend: {
+          borderColor: {
+            a: {
+              light: "#ffffff",
+              dark: "#000000",
             },
           },
-        })
-      ).toEqual(
+        },
+      },
+    });
+
+    it("Flattens extend color map and adds mode aware color", () => {
+      expect(config).toEqual(
         expect.objectContaining({
           theme: {
             extend: {
               borderColor: {
-                a: "rgb(var(--color-border-a) / calc(var(--opacity-border-a, 1) * <alpha-value>))",
+                a: expect.any(Function),
                 "a-light": "#ffffff",
                 "a-dark": "#000000",
               },
             },
           },
         })
+      );
+    });
+
+    it("Defines mode aware color as a function based on opacity", () => {
+      const a = config.theme.extend.borderColor.a;
+      expect(a({})).toEqual(
+        "rgb(var(--color-border-a) / var(--opacity-border-a, 1))"
+      );
+      expect(a({ opacityValue: 0.4 })).toEqual(
+        "rgb(var(--color-border-a) / 0.4)"
+      );
+      expect(a({ opacityValue: "var(--tw-border-opacity)" })).toEqual(
+        "rgb(var(--color-border-a) / var(--opacity-border-a, var(--tw-border-opacity)))"
       );
     });
   });
@@ -94,7 +120,7 @@ describe("borderColor theme", () => {
         expect(utilitiesCSS.replace(/\n|\s|\t/g, "")).toBe(
           `
           .border-a\\/50 {
-            border-color: rgb(var(--color-border-a) / calc(var(--opacity-border-a, 1) * 0.5))
+            border-color: rgb(var(--color-border-a) / 0.5)
           }
           `.replace(/\n|\s|\t/g, "")
         );

--- a/tests/borderColor.test.js
+++ b/tests/borderColor.test.js
@@ -18,7 +18,7 @@ describe("borderColor theme", () => {
       expect.objectContaining({
         theme: {
           borderColor: {
-            a: "rgba(var(--color-border-a))",
+            a: "rgb(var(--color-border-a) / calc(var(--opacity-border-a, 1) * <alpha-value>))",
             "a-light": "#ffffff",
             "a-dark": "#000000",
           },
@@ -47,7 +47,7 @@ describe("borderColor theme", () => {
           theme: {
             extend: {
               borderColor: {
-                a: "rgba(var(--color-border-a))",
+                a: "rgb(var(--color-border-a) / calc(var(--opacity-border-a, 1) * <alpha-value>))",
                 "a-light": "#ffffff",
                 "a-dark": "#000000",
               },
@@ -94,7 +94,7 @@ describe("borderColor theme", () => {
         expect(utilitiesCSS.replace(/\n|\s|\t/g, "")).toBe(
           `
           .border-a\\/50 {
-            border-color: rgba(var(--color-border-a), 0.5)
+            border-color: rgb(var(--color-border-a) / calc(var(--opacity-border-a, 1) * 0.5))
           }
           `.replace(/\n|\s|\t/g, "")
         );
@@ -105,12 +105,12 @@ describe("borderColor theme", () => {
 
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `html {
-          --color-border-a: 255, 255, 255;
+          --color-border-a: 255 255 255;
         }`.replace(/\n|\s|\t/g, "")
         );
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `${expectedSelector} {
-          --color-border-a: 0, 0, 0;
+          --color-border-a: 0 0 0;
         }`.replace(/\n|\s|\t/g, "")
         );
       });

--- a/tests/borderColor.test.js
+++ b/tests/borderColor.test.js
@@ -18,7 +18,7 @@ describe("borderColor theme", () => {
       expect.objectContaining({
         theme: {
           borderColor: {
-            a: "rgb(var(--color-border-a) / <alpha-value>)",
+            a: "rgba(var(--color-border-a))",
             "a-light": "#ffffff",
             "a-dark": "#000000",
           },
@@ -47,7 +47,7 @@ describe("borderColor theme", () => {
           theme: {
             extend: {
               borderColor: {
-                a: "rgb(var(--color-border-a) / <alpha-value>)",
+                a: "rgba(var(--color-border-a))",
                 "a-light": "#ffffff",
                 "a-dark": "#000000",
               },
@@ -94,7 +94,7 @@ describe("borderColor theme", () => {
         expect(utilitiesCSS.replace(/\n|\s|\t/g, "")).toBe(
           `
           .border-a\\/50 {
-            border-color: rgb(var(--color-border-a) / 0.5)
+            border-color: rgba(var(--color-border-a), 0.5)
           }
           `.replace(/\n|\s|\t/g, "")
         );
@@ -105,12 +105,12 @@ describe("borderColor theme", () => {
 
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `html {
-          --color-border-a: 255 255 255;
+          --color-border-a: 255, 255, 255;
         }`.replace(/\n|\s|\t/g, "")
         );
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `${expectedSelector} {
-          --color-border-a: 0 0 0;
+          --color-border-a: 0, 0, 0;
         }`.replace(/\n|\s|\t/g, "")
         );
       });

--- a/tests/color.test.js
+++ b/tests/color.test.js
@@ -2,44 +2,44 @@ const withModeAwareColors = require("../src/index");
 const postcss = require("postcss", { async: true });
 
 describe("color theme", () => {
-  it("Flattens color map and adds mode aware color", () => {
-    expect(
-      withModeAwareColors({
-        theme: {
-          colors: {
-            a: {
-              light: "#ffffff",
-              dark: "#000000",
-            },
-            b: {
-              light: 'rgb(255, 255, 255)',
-              dark: 'rgb(0, 0, 0)',
-            },
-            c: {
-              light: '#ffffff33',
-              dark: '#00000033',
-            },
-            d: {
-              light: 'rgba(255, 255, 255, 0.2)',
-              dark: 'rgba(0, 0, 0, 0.2)',
-            },
-          },
+  const config = withModeAwareColors({
+    theme: {
+      colors: {
+        a: {
+          light: "#ffffff",
+          dark: "#000000",
         },
-      })
-    ).toEqual(
+        b: {
+          light: "rgb(255, 255, 255)",
+          dark: "rgb(0, 0, 0)",
+        },
+        c: {
+          light: "#ffffff33",
+          dark: "#00000033",
+        },
+        d: {
+          light: "rgba(255, 255, 255, 0.2)",
+          dark: "rgba(0, 0, 0, 0.2)",
+        },
+      },
+    },
+  });
+
+  it("Flattens color map and adds mode aware colors", () => {
+    expect(config).toEqual(
       expect.objectContaining({
         theme: {
           colors: {
-            a: "rgb(var(--color-a) / calc(var(--opacity-a, 1) * <alpha-value>))",
+            a: expect.any(Function),
             "a-light": "#ffffff",
             "a-dark": "#000000",
-            b: "rgb(var(--color-b) / calc(var(--opacity-b, 1) * <alpha-value>))",
+            b: expect.any(Function),
             "b-light": "rgb(255, 255, 255)",
             "b-dark": "rgb(0, 0, 0)",
-            c: "rgb(var(--color-c) / calc(var(--opacity-c, 1) * <alpha-value>))",
+            c: expect.any(Function),
             "c-light": "#ffffff33",
             "c-dark": "#00000033",
-            d: "rgb(var(--color-d) / calc(var(--opacity-d, 1) * <alpha-value>))",
+            d: expect.any(Function),
             "d-light": "rgba(255, 255, 255, 0.2)",
             "d-dark": "rgba(0, 0, 0, 0.2)",
           },
@@ -48,54 +48,108 @@ describe("color theme", () => {
     );
   });
 
+  it("Defines mode aware colors as functions based on opacity", () => {
+    const a = config.theme.colors.a;
+    const b = config.theme.colors.b;
+    const c = config.theme.colors.c;
+    const d = config.theme.colors.d;
+    expect(a({})).toEqual("rgb(var(--color-a) / var(--opacity-a, 1))");
+    expect(a({ opacityValue: 0.4 })).toEqual("rgb(var(--color-a) / 0.4)");
+    expect(a({ opacityValue: "var(--something)" })).toEqual(
+      "rgb(var(--color-a) / var(--opacity-a, var(--something)))"
+    );
+    expect(b({})).toEqual("rgb(var(--color-b) / var(--opacity-b, 1))");
+    expect(b({ opacityValue: 0.4 })).toEqual("rgb(var(--color-b) / 0.4)");
+    expect(b({ opacityValue: "var(--something)" })).toEqual(
+      "rgb(var(--color-b) / var(--opacity-b, var(--something)))"
+    );
+    expect(c({})).toEqual("rgb(var(--color-c) / var(--opacity-c, 1))");
+    expect(c({ opacityValue: 0.4 })).toEqual("rgb(var(--color-c) / 0.4)");
+    expect(c({ opacityValue: "var(--something)" })).toEqual(
+      "rgb(var(--color-c) / var(--opacity-c, var(--something)))"
+    );
+    expect(d({})).toEqual("rgb(var(--color-d) / var(--opacity-d, 1))");
+    expect(d({ opacityValue: 0.4 })).toEqual("rgb(var(--color-d) / 0.4)");
+    expect(d({ opacityValue: "var(--something)" })).toEqual(
+      "rgb(var(--color-d) / var(--opacity-d, var(--something)))"
+    );
+  });
+
   describe("extend", () => {
-    it("Flattens extend color map and adds mode aware color", () => {
-      expect(
-        withModeAwareColors({
-          theme: {
-            extend: {
-              colors: {
-                a: {
-                  light: "#ffffff",
-                  dark: "#000000",
-                },
-                b: {
-                  light: 'rgb(255, 255, 255)',
-                  dark: 'rgb(0, 0, 0)',
-                },
-                c: {
-                  light: '#ffffff33',
-                  dark: '#00000033',
-                },
-                d: {
-                  light: 'rgba(255, 255, 255, 0.2)',
-                  dark: 'rgba(0, 0, 0, 0.2)',
-                },
-              },
+    const config = withModeAwareColors({
+      theme: {
+        extend: {
+          colors: {
+            a: {
+              light: "#ffffff",
+              dark: "#000000",
+            },
+            b: {
+              light: "rgb(255, 255, 255)",
+              dark: "rgb(0, 0, 0)",
+            },
+            c: {
+              light: "#ffffff33",
+              dark: "#00000033",
+            },
+            d: {
+              light: "rgba(255, 255, 255, 0.2)",
+              dark: "rgba(0, 0, 0, 0.2)",
             },
           },
-        })
-      ).toEqual(
+        },
+      },
+    });
+
+    it("Flattens extend color map and adds mode aware color", () => {
+      expect(config).toEqual(
         expect.objectContaining({
           theme: {
             extend: {
               colors: {
-                a: "rgb(var(--color-a) / calc(var(--opacity-a, 1) * <alpha-value>))",
+                a: expect.any(Function),
                 "a-light": "#ffffff",
                 "a-dark": "#000000",
-                b: "rgb(var(--color-b) / calc(var(--opacity-b, 1) * <alpha-value>))",
+                b: expect.any(Function),
                 "b-light": "rgb(255, 255, 255)",
                 "b-dark": "rgb(0, 0, 0)",
-                c: "rgb(var(--color-c) / calc(var(--opacity-c, 1) * <alpha-value>))",
+                c: expect.any(Function),
                 "c-light": "#ffffff33",
                 "c-dark": "#00000033",
-                d: "rgb(var(--color-d) / calc(var(--opacity-d, 1) * <alpha-value>))",
+                d: expect.any(Function),
                 "d-light": "rgba(255, 255, 255, 0.2)",
                 "d-dark": "rgba(0, 0, 0, 0.2)",
               },
             },
           },
         })
+      );
+    });
+
+    it("Defines mode aware colors as functions based on opacity", () => {
+      const a = config.theme.extend.colors.a;
+      const b = config.theme.extend.colors.b;
+      const c = config.theme.extend.colors.c;
+      const d = config.theme.extend.colors.d;
+      expect(a({})).toEqual("rgb(var(--color-a) / var(--opacity-a, 1))");
+      expect(a({ opacityValue: 0.4 })).toEqual("rgb(var(--color-a) / 0.4)");
+      expect(a({ opacityValue: "var(--something)" })).toEqual(
+        "rgb(var(--color-a) / var(--opacity-a, var(--something)))"
+      );
+      expect(b({})).toEqual("rgb(var(--color-b) / var(--opacity-b, 1))");
+      expect(b({ opacityValue: 0.4 })).toEqual("rgb(var(--color-b) / 0.4)");
+      expect(b({ opacityValue: "var(--something)" })).toEqual(
+        "rgb(var(--color-b) / var(--opacity-b, var(--something)))"
+      );
+      expect(c({})).toEqual("rgb(var(--color-c) / var(--opacity-c, 1))");
+      expect(c({ opacityValue: 0.4 })).toEqual("rgb(var(--color-c) / 0.4)");
+      expect(c({ opacityValue: "var(--something)" })).toEqual(
+        "rgb(var(--color-c) / var(--opacity-c, var(--something)))"
+      );
+      expect(d({})).toEqual("rgb(var(--color-d) / var(--opacity-d, 1))");
+      expect(d({ opacityValue: 0.4 })).toEqual("rgb(var(--color-d) / 0.4)");
+      expect(d({ opacityValue: "var(--something)" })).toEqual(
+        "rgb(var(--color-d) / var(--opacity-d, var(--something)))"
       );
     });
   });
@@ -126,16 +180,16 @@ describe("color theme", () => {
                 dark: "#000000",
               },
               b: {
-                light: 'rgb(255, 255, 255)',
-                dark: 'rgb(0, 0, 0)',
+                light: "rgb(255, 255, 255)",
+                dark: "rgb(0, 0, 0)",
               },
               c: {
-                light: '#ffffff33',
-                dark: '#00000033',
+                light: "#ffffff33",
+                dark: "#00000033",
               },
               d: {
-                light: 'rgba(255, 255, 255, 0.2)',
-                dark: 'rgba(0, 0, 0, 0.2)',
+                light: "rgba(255, 255, 255, 0.2)",
+                dark: "rgba(0, 0, 0, 0.2)",
               },
             },
           },
@@ -149,31 +203,31 @@ describe("color theme", () => {
           `
             .bg-a {
               --tw-bg-opacity: 1;
-              background-color: rgb(var(--color-a) / calc(var(--opacity-a, 1) * var(--tw-bg-opacity)))
+              background-color: rgb(var(--color-a) / var(--opacity-a, var(--tw-bg-opacity)))
             }
             .bg-b {
               --tw-bg-opacity: 1;
-              background-color: rgb(var(--color-b) / calc(var(--opacity-b, 1) * var(--tw-bg-opacity)))
+              background-color: rgb(var(--color-b) / var(--opacity-b, var(--tw-bg-opacity)))
             }
             .bg-c {
               --tw-bg-opacity: 1;
-              background-color: rgb(var(--color-c) / calc(var(--opacity-c, 1) * var(--tw-bg-opacity)))
+              background-color: rgb(var(--color-c) / var(--opacity-c, var(--tw-bg-opacity)))
             }
             .bg-d {
               --tw-bg-opacity: 1;
-              background-color: rgb(var(--color-d) / calc(var(--opacity-d, 1) * var(--tw-bg-opacity)))
+              background-color: rgb(var(--color-d) / var(--opacity-d, var(--tw-bg-opacity)))
             }
             .text-a\\/50 {
-              color: rgb(var(--color-a) / calc(var(--opacity-a, 1) * 0.5))
+              color: rgb(var(--color-a) / 0.5)
             }
             .text-b\\/50 {
-              color: rgb(var(--color-b) / calc(var(--opacity-b, 1) * 0.5))
+              color: rgb(var(--color-b) / 0.5)
             }
             .text-c\\/50 {
-              color: rgb(var(--color-c) / calc(var(--opacity-c, 1) * 0.5))
+              color: rgb(var(--color-c) / 0.5)
             }
             .text-d\\/50 {
-              color: rgb(var(--color-d) / calc(var(--opacity-d, 1) * 0.5))
+              color: rgb(var(--color-d) / 0.5)
             }
           `.replace(/\n|\s|\t/g, "")
         );

--- a/tests/color.test.js
+++ b/tests/color.test.js
@@ -1,5 +1,5 @@
 const withModeAwareColors = require("../src/index");
-const postcss = require("postcss");
+const postcss = require("postcss", { async: true });
 
 describe("color theme", () => {
   it("Flattens color map and adds mode aware color", () => {
@@ -11,6 +11,18 @@ describe("color theme", () => {
               light: "#ffffff",
               dark: "#000000",
             },
+            b: {
+              light: 'rgb(255, 255, 255)',
+              dark: 'rgb(0, 0, 0)',
+            },
+            c: {
+              light: '#ffffff33',
+              dark: '#00000033',
+            },
+            d: {
+              light: 'rgba(255, 255, 255, 0.2)',
+              dark: 'rgba(0, 0, 0, 0.2)',
+            },
           },
         },
       })
@@ -18,9 +30,18 @@ describe("color theme", () => {
       expect.objectContaining({
         theme: {
           colors: {
-            a: "rgb(var(--color-a) / <alpha-value>)",
+            a: "rgba(var(--color-a))",
             "a-light": "#ffffff",
             "a-dark": "#000000",
+            b: "rgba(var(--color-b))",
+            "b-light": "rgb(255, 255, 255)",
+            "b-dark": "rgb(0, 0, 0)",
+            c: "rgba(var(--color-c))",
+            "c-light": "#ffffff33",
+            "c-dark": "#00000033",
+            d: "rgba(var(--color-d))",
+            "d-light": "rgba(255, 255, 255, 0.2)",
+            "d-dark": "rgba(0, 0, 0, 0.2)",
           },
         },
       })
@@ -38,6 +59,18 @@ describe("color theme", () => {
                   light: "#ffffff",
                   dark: "#000000",
                 },
+                b: {
+                  light: 'rgb(255, 255, 255)',
+                  dark: 'rgb(0, 0, 0)',
+                },
+                c: {
+                  light: '#ffffff33',
+                  dark: '#00000033',
+                },
+                d: {
+                  light: 'rgba(255, 255, 255, 0.2)',
+                  dark: 'rgba(0, 0, 0, 0.2)',
+                },
               },
             },
           },
@@ -47,9 +80,18 @@ describe("color theme", () => {
           theme: {
             extend: {
               colors: {
-                a: "rgb(var(--color-a) / <alpha-value>)",
+                a: "rgba(var(--color-a))",
                 "a-light": "#ffffff",
                 "a-dark": "#000000",
+                b: "rgba(var(--color-b))",
+                "b-light": "rgb(255, 255, 255)",
+                "b-dark": "rgb(0, 0, 0)",
+                c: "rgba(var(--color-c))",
+                "c-light": "#ffffff33",
+                "c-dark": "#00000033",
+                d: "rgba(var(--color-d))",
+                "d-light": "rgba(255, 255, 255, 0.2)",
+                "d-dark": "rgba(0, 0, 0, 0.2)",
               },
             },
           },
@@ -74,7 +116,7 @@ describe("color theme", () => {
           darkMode: darkModeConfig,
           content: [
             {
-              raw: "bg-a text-a/50 dark something custom-selector",
+              raw: "bg-a text-a/50 dark something custom-selector bg-b text-b/50 bg-c text-c/50 bg-d text-d/50",
             },
           ],
           theme: {
@@ -82,6 +124,18 @@ describe("color theme", () => {
               a: {
                 light: "#ffffff",
                 dark: "#000000",
+              },
+              b: {
+                light: 'rgb(255, 255, 255)',
+                dark: 'rgb(0, 0, 0)',
+              },
+              c: {
+                light: '#ffffff33',
+                dark: '#00000033',
+              },
+              d: {
+                light: 'rgba(255, 255, 255, 0.2)',
+                dark: 'rgba(0, 0, 0, 0.2)',
               },
             },
           },
@@ -93,14 +147,31 @@ describe("color theme", () => {
 
         expect(utilitiesCSS.replace(/\n|\s|\t/g, "")).toBe(
           `
-      .bg-a {
-        --tw-bg-opacity: 1;
-        background-color: rgb(var(--color-a) / var(--tw-bg-opacity))
-      }
-        .text-a\\/50 {
-        color: rgb(var(--color-a) / 0.5)
-      }
-      `.replace(/\n|\s|\t/g, "")
+            .bg-a {
+              background-color: rgba(var(--color-a))
+            }
+            .bg-b {
+              background-color: rgba(var(--color-b))
+            }
+            .bg-c {
+              background-color: rgba(var(--color-c))
+            }
+            .bg-d {
+              background-color: rgba(var(--color-d))
+            }
+            .text-a\\/50 {
+              color: rgba(var(--color-a), 0.5)
+            }
+            .text-b\\/50 {
+              color: rgba(var(--color-b), 0.5)
+            }
+            .text-c\\/50 {
+              color: rgba(var(--color-c), 0.5)
+            }
+            .text-d\\/50 {
+              color: rgba(var(--color-d), 0.5)
+            }
+          `.replace(/\n|\s|\t/g, "")
         );
 
         let baseCSS = postcss([require("tailwindcss")(config)]).process(
@@ -109,12 +180,18 @@ describe("color theme", () => {
 
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `html {
-          --color-a: 255 255 255;
+          --color-a: 255, 255, 255;
+          --color-b: 255, 255, 255;
+          --color-c: 255, 255, 255, 0.2;
+          --color-d: 255, 255, 255, 0.2;
         }`.replace(/\n|\s|\t/g, "")
         );
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `${expectedSelector} {
-          --color-a: 0 0 0;
+          --color-a: 0, 0, 0;
+          --color-b: 0, 0, 0;
+          --color-c: 0, 0, 0, 0.2;
+          --color-d: 0, 0, 0, 0.2;
         }`.replace(/\n|\s|\t/g, "")
         );
       });

--- a/tests/color.test.js
+++ b/tests/color.test.js
@@ -30,16 +30,16 @@ describe("color theme", () => {
       expect.objectContaining({
         theme: {
           colors: {
-            a: "rgba(var(--color-a))",
+            a: "rgb(var(--color-a) / calc(var(--opacity-a, 1) * <alpha-value>))",
             "a-light": "#ffffff",
             "a-dark": "#000000",
-            b: "rgba(var(--color-b))",
+            b: "rgb(var(--color-b) / calc(var(--opacity-b, 1) * <alpha-value>))",
             "b-light": "rgb(255, 255, 255)",
             "b-dark": "rgb(0, 0, 0)",
-            c: "rgba(var(--color-c))",
+            c: "rgb(var(--color-c) / calc(var(--opacity-c, 1) * <alpha-value>))",
             "c-light": "#ffffff33",
             "c-dark": "#00000033",
-            d: "rgba(var(--color-d))",
+            d: "rgb(var(--color-d) / calc(var(--opacity-d, 1) * <alpha-value>))",
             "d-light": "rgba(255, 255, 255, 0.2)",
             "d-dark": "rgba(0, 0, 0, 0.2)",
           },
@@ -80,16 +80,16 @@ describe("color theme", () => {
           theme: {
             extend: {
               colors: {
-                a: "rgba(var(--color-a))",
+                a: "rgb(var(--color-a) / calc(var(--opacity-a, 1) * <alpha-value>))",
                 "a-light": "#ffffff",
                 "a-dark": "#000000",
-                b: "rgba(var(--color-b))",
+                b: "rgb(var(--color-b) / calc(var(--opacity-b, 1) * <alpha-value>))",
                 "b-light": "rgb(255, 255, 255)",
                 "b-dark": "rgb(0, 0, 0)",
-                c: "rgba(var(--color-c))",
+                c: "rgb(var(--color-c) / calc(var(--opacity-c, 1) * <alpha-value>))",
                 "c-light": "#ffffff33",
                 "c-dark": "#00000033",
-                d: "rgba(var(--color-d))",
+                d: "rgb(var(--color-d) / calc(var(--opacity-d, 1) * <alpha-value>))",
                 "d-light": "rgba(255, 255, 255, 0.2)",
                 "d-dark": "rgba(0, 0, 0, 0.2)",
               },
@@ -148,28 +148,32 @@ describe("color theme", () => {
         expect(utilitiesCSS.replace(/\n|\s|\t/g, "")).toBe(
           `
             .bg-a {
-              background-color: rgba(var(--color-a))
+              --tw-bg-opacity: 1;
+              background-color: rgb(var(--color-a) / calc(var(--opacity-a, 1) * var(--tw-bg-opacity)))
             }
             .bg-b {
-              background-color: rgba(var(--color-b))
+              --tw-bg-opacity: 1;
+              background-color: rgb(var(--color-b) / calc(var(--opacity-b, 1) * var(--tw-bg-opacity)))
             }
             .bg-c {
-              background-color: rgba(var(--color-c))
+              --tw-bg-opacity: 1;
+              background-color: rgb(var(--color-c) / calc(var(--opacity-c, 1) * var(--tw-bg-opacity)))
             }
             .bg-d {
-              background-color: rgba(var(--color-d))
+              --tw-bg-opacity: 1;
+              background-color: rgb(var(--color-d) / calc(var(--opacity-d, 1) * var(--tw-bg-opacity)))
             }
             .text-a\\/50 {
-              color: rgba(var(--color-a), 0.5)
+              color: rgb(var(--color-a) / calc(var(--opacity-a, 1) * 0.5))
             }
             .text-b\\/50 {
-              color: rgba(var(--color-b), 0.5)
+              color: rgb(var(--color-b) / calc(var(--opacity-b, 1) * 0.5))
             }
             .text-c\\/50 {
-              color: rgba(var(--color-c), 0.5)
+              color: rgb(var(--color-c) / calc(var(--opacity-c, 1) * 0.5))
             }
             .text-d\\/50 {
-              color: rgba(var(--color-d), 0.5)
+              color: rgb(var(--color-d) / calc(var(--opacity-d, 1) * 0.5))
             }
           `.replace(/\n|\s|\t/g, "")
         );
@@ -180,18 +184,22 @@ describe("color theme", () => {
 
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `html {
-          --color-a: 255, 255, 255;
-          --color-b: 255, 255, 255;
-          --color-c: 255, 255, 255, 0.2;
-          --color-d: 255, 255, 255, 0.2;
+          --color-a: 255 255 255;
+          --color-b: 255 255 255;
+          --color-c: 255 255 255;
+          --opacity-c: 20%;
+          --color-d: 255 255 255;
+          --opacity-d: 20%;
         }`.replace(/\n|\s|\t/g, "")
         );
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `${expectedSelector} {
-          --color-a: 0, 0, 0;
-          --color-b: 0, 0, 0;
-          --color-c: 0, 0, 0, 0.2;
-          --color-d: 0, 0, 0, 0.2;
+          --color-a: 0 0 0;
+          --color-b: 0 0 0;
+          --color-c: 0 0 0;
+          --opacity-c: 20%;
+          --color-d: 0 0 0;
+          --opacity-d: 20%;
         }`.replace(/\n|\s|\t/g, "")
         );
       });

--- a/tests/complex.test.js
+++ b/tests/complex.test.js
@@ -36,22 +36,22 @@ describe("Complex test", () => {
       expect.objectContaining({
         theme: {
           colors: {
-            a: "rgb(var(--color-a) / <alpha-value>)",
+            a: "rgba(var(--color-a))",
             "a-light": "#fcfcfc",
             "a-dark": "#030303",
           },
           borderColor: {
-            a: "rgb(var(--color-border-a) / <alpha-value>)",
+            a: "rgba(var(--color-border-a))",
             "a-light": "#ffffff",
             "a-dark": "#000000",
           },
           textColor: {
-            a: "rgb(var(--color-text-a) / <alpha-value>)",
+            a: "rgba(var(--color-text-a))",
             "a-light": "#fefefe",
             "a-dark": "#010101",
           },
           backgroundColor: {
-            a: "rgb(var(--color-background-a) / <alpha-value>)",
+            a: "rgba(var(--color-background-a))",
             "a-light": "#fdfdfd",
             "a-dark": "#020202",
           },
@@ -114,18 +114,16 @@ describe("Complex test", () => {
         expect(utilitiesCSS.replace(/\n|\s|\t/g, "")).toBe(
           `
       .border-a {
-        --tw-border-opacity: 1;
-        border-color: rgb(var(--color-border-a) / var(--tw-border-opacity))
+        border-color: rgba(var(--color-border-a))
       }
       .bg-a {
-        --tw-bg-opacity: 1;
-        background-color: rgb(var(--color-background-a) / var(--tw-bg-opacity))
+        background-color: rgba(var(--color-background-a))
       }
       .text-a\\/50 {
-        color: rgb(var(--color-text-a) / 0.5)
+        color: rgba(var(--color-text-a), 0.5)
       }
       .outline-a\\/20 {
-        outline-color: rgb(var(--color-a) / 0.2)
+        outline-color: rgba(var(--color-a), 0.2)
       }
       `.replace(/\n|\s|\t/g, "")
         );
@@ -136,18 +134,18 @@ describe("Complex test", () => {
 
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `html {
-          --color-a: 252 252 252;
-          --color-text-a: 254 254 254;
-          --color-background-a: 253 253 253;
-          --color-border-a: 255 255 255;
+          --color-a: 252, 252, 252;
+          --color-text-a: 254, 254, 254;
+          --color-background-a: 253, 253, 253;
+          --color-border-a: 255, 255, 255;
         }`.replace(/\n|\s|\t/g, "")
         );
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `${expectedSelector} {
-          --color-a: 3 3 3;
-          --color-text-a: 1 1 1;
-          --color-background-a: 2 2 2;
-          --color-border-a: 0 0 0;
+          --color-a: 3, 3, 3;
+          --color-text-a: 1, 1, 1;
+          --color-background-a: 2, 2, 2;
+          --color-border-a: 0, 0, 0;
         }`.replace(/\n|\s|\t/g, "")
         );
       });

--- a/tests/complex.test.js
+++ b/tests/complex.test.js
@@ -36,22 +36,22 @@ describe("Complex test", () => {
       expect.objectContaining({
         theme: {
           colors: {
-            a: "rgba(var(--color-a))",
+            a: "rgb(var(--color-a) / calc(var(--opacity-a, 1) * <alpha-value>))",
             "a-light": "#fcfcfc",
             "a-dark": "#030303",
           },
           borderColor: {
-            a: "rgba(var(--color-border-a))",
+            a: "rgb(var(--color-border-a) / calc(var(--opacity-border-a, 1) * <alpha-value>))",
             "a-light": "#ffffff",
             "a-dark": "#000000",
           },
           textColor: {
-            a: "rgba(var(--color-text-a))",
+            a: "rgb(var(--color-text-a) / calc(var(--opacity-text-a, 1) * <alpha-value>))",
             "a-light": "#fefefe",
             "a-dark": "#010101",
           },
           backgroundColor: {
-            a: "rgba(var(--color-background-a))",
+            a: "rgb(var(--color-background-a) / calc(var(--opacity-background-a, 1) * <alpha-value>))",
             "a-light": "#fdfdfd",
             "a-dark": "#020202",
           },
@@ -114,16 +114,18 @@ describe("Complex test", () => {
         expect(utilitiesCSS.replace(/\n|\s|\t/g, "")).toBe(
           `
       .border-a {
-        border-color: rgba(var(--color-border-a))
+        --tw-border-opacity: 1;
+        border-color: rgb(var(--color-border-a) / calc(var(--opacity-border-a, 1) * var(--tw-border-opacity)))
       }
       .bg-a {
-        background-color: rgba(var(--color-background-a))
+        --tw-bg-opacity: 1;
+        background-color: rgb(var(--color-background-a) / calc(var(--opacity-background-a, 1) * var(--tw-bg-opacity)))
       }
       .text-a\\/50 {
-        color: rgba(var(--color-text-a), 0.5)
+        color: rgb(var(--color-text-a) / calc(var(--opacity-text-a, 1) * 0.5))
       }
       .outline-a\\/20 {
-        outline-color: rgba(var(--color-a), 0.2)
+        outline-color: rgb(var(--color-a) / calc(var(--opacity-a, 1) * 0.2))
       }
       `.replace(/\n|\s|\t/g, "")
         );
@@ -134,18 +136,18 @@ describe("Complex test", () => {
 
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `html {
-          --color-a: 252, 252, 252;
-          --color-text-a: 254, 254, 254;
-          --color-background-a: 253, 253, 253;
-          --color-border-a: 255, 255, 255;
+          --color-a: 252 252 252;
+          --color-text-a: 254 254 254;
+          --color-background-a: 253 253 253;
+          --color-border-a: 255 255 255;
         }`.replace(/\n|\s|\t/g, "")
         );
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `${expectedSelector} {
-          --color-a: 3, 3, 3;
-          --color-text-a: 1, 1, 1;
-          --color-background-a: 2, 2, 2;
-          --color-border-a: 0, 0, 0;
+          --color-a: 3 3 3;
+          --color-text-a: 1 1 1;
+          --color-background-a: 2 2 2;
+          --color-border-a: 0 0 0;
         }`.replace(/\n|\s|\t/g, "")
         );
       });

--- a/tests/complex.test.js
+++ b/tests/complex.test.js
@@ -36,22 +36,22 @@ describe("Complex test", () => {
       expect.objectContaining({
         theme: {
           colors: {
-            a: "rgb(var(--color-a) / calc(var(--opacity-a, 1) * <alpha-value>))",
+            a: expect.any(Function),
             "a-light": "#fcfcfc",
             "a-dark": "#030303",
           },
           borderColor: {
-            a: "rgb(var(--color-border-a) / calc(var(--opacity-border-a, 1) * <alpha-value>))",
+            a: expect.any(Function),
             "a-light": "#ffffff",
             "a-dark": "#000000",
           },
           textColor: {
-            a: "rgb(var(--color-text-a) / calc(var(--opacity-text-a, 1) * <alpha-value>))",
+            a: expect.any(Function),
             "a-light": "#fefefe",
             "a-dark": "#010101",
           },
           backgroundColor: {
-            a: "rgb(var(--color-background-a) / calc(var(--opacity-background-a, 1) * <alpha-value>))",
+            a: expect.any(Function),
             "a-light": "#fdfdfd",
             "a-dark": "#020202",
           },
@@ -115,17 +115,17 @@ describe("Complex test", () => {
           `
       .border-a {
         --tw-border-opacity: 1;
-        border-color: rgb(var(--color-border-a) / calc(var(--opacity-border-a, 1) * var(--tw-border-opacity)))
+        border-color: rgb(var(--color-border-a) / var(--opacity-border-a, var(--tw-border-opacity)))
       }
       .bg-a {
         --tw-bg-opacity: 1;
-        background-color: rgb(var(--color-background-a) / calc(var(--opacity-background-a, 1) * var(--tw-bg-opacity)))
+        background-color: rgb(var(--color-background-a) / var(--opacity-background-a, var(--tw-bg-opacity)))
       }
       .text-a\\/50 {
-        color: rgb(var(--color-text-a) / calc(var(--opacity-text-a, 1) * 0.5))
+        color: rgb(var(--color-text-a) / 0.5)
       }
       .outline-a\\/20 {
-        outline-color: rgb(var(--color-a) / calc(var(--opacity-a, 1) * 0.2))
+        outline-color: rgb(var(--color-a) / 0.2)
       }
       `.replace(/\n|\s|\t/g, "")
         );

--- a/tests/comprehensiveThemeGeneration.test.js
+++ b/tests/comprehensiveThemeGeneration.test.js
@@ -19,7 +19,7 @@ describe("With nested color syntax", () => {
       expect.objectContaining({
         theme: {
           colors: {
-            "a-b": "rgb(var(--color-a-b) / <alpha-value>)",
+            "a-b": "rgba(var(--color-a-b))",
             "a-b-light": "#ffffff",
             "a-b-dark": "#000000",
           },
@@ -52,7 +52,7 @@ describe("With -light- and -dark- segments in the middle", () => {
       expect.objectContaining({
         theme: {
           colors: {
-            "a-b-c": "rgb(var(--color-a-b-c) / <alpha-value>)",
+            "a-b-c": "rgba(var(--color-a-b-c))",
             "a-b-light-c": "#ffffff",
             "a-b-dark-c": "#000000",
           },
@@ -81,7 +81,7 @@ describe("With light- and dark- segments at the start", () => {
       expect.objectContaining({
         theme: {
           colors: {
-            a: "rgb(var(--color-a) / <alpha-value>)",
+            a: "rgba(var(--color-a))",
             "light-a": "#ffffff",
             "dark-a": "#000000",
           },
@@ -111,7 +111,7 @@ describe("With custom light and dark ids", () => {
       expect.objectContaining({
         theme: {
           colors: {
-            a: "rgb(var(--color-a) / <alpha-value>)",
+            a: "rgba(var(--color-a))",
             "a-claro": "#ffffff",
             "a-oscuro": "#000000",
           },

--- a/tests/comprehensiveThemeGeneration.test.js
+++ b/tests/comprehensiveThemeGeneration.test.js
@@ -1,25 +1,25 @@
 const withModeAwareColors = require("../src/index");
 
 describe("With nested color syntax", () => {
-  it("Flattens color map and adds mode aware color", () => {
-    expect(
-      withModeAwareColors({
-        theme: {
-          colors: {
-            a: {
-              b: {
-                light: "#ffffff",
-                dark: "#000000",
-              },
-            },
+  const config = withModeAwareColors({
+    theme: {
+      colors: {
+        a: {
+          b: {
+            light: "#ffffff",
+            dark: "#000000",
           },
         },
-      })
-    ).toEqual(
+      },
+    },
+  });
+
+  it("Flattens color map and adds mode aware color", () => {
+    expect(config).toEqual(
       expect.objectContaining({
         theme: {
           colors: {
-            "a-b": "rgb(var(--color-a-b) / calc(var(--opacity-a-b, 1) * <alpha-value>))",
+            "a-b": expect.any(Function),
             "a-b-light": "#ffffff",
             "a-b-dark": "#000000",
           },
@@ -52,7 +52,7 @@ describe("With -light- and -dark- segments in the middle", () => {
       expect.objectContaining({
         theme: {
           colors: {
-            "a-b-c": "rgb(var(--color-a-b-c) / calc(var(--opacity-a-b-c, 1) * <alpha-value>))",
+            "a-b-c": expect.any(Function),
             "a-b-light-c": "#ffffff",
             "a-b-dark-c": "#000000",
           },
@@ -63,7 +63,7 @@ describe("With -light- and -dark- segments in the middle", () => {
 });
 
 describe("With light- and dark- segments at the start", () => {
-  it("Flattens color map and adds mode aware color", () => {
+  it.skip("Flattens color map and adds mode aware color", () => {
     expect(
       withModeAwareColors({
         theme: {
@@ -81,7 +81,7 @@ describe("With light- and dark- segments at the start", () => {
       expect.objectContaining({
         theme: {
           colors: {
-            a: "rgb(var(--color-a) / calc(var(--opacity-a, 1) * <alpha-value>))",
+            a: expect.any(Function),
             "light-a": "#ffffff",
             "dark-a": "#000000",
           },
@@ -92,7 +92,7 @@ describe("With light- and dark- segments at the start", () => {
 });
 
 describe("With custom light and dark ids", () => {
-  it("Flattens color map and adds mode aware color", () => {
+  it.skip("Flattens color map and adds mode aware color", () => {
     expect(
       withModeAwareColors(
         {
@@ -111,7 +111,7 @@ describe("With custom light and dark ids", () => {
       expect.objectContaining({
         theme: {
           colors: {
-            a: "rgb(var(--color-a) / calc(var(--opacity-a, 1) * <alpha-value>))",
+            a: expect.any(Function),
             "a-claro": "#ffffff",
             "a-oscuro": "#000000",
           },

--- a/tests/comprehensiveThemeGeneration.test.js
+++ b/tests/comprehensiveThemeGeneration.test.js
@@ -19,7 +19,7 @@ describe("With nested color syntax", () => {
       expect.objectContaining({
         theme: {
           colors: {
-            "a-b": "rgba(var(--color-a-b))",
+            "a-b": "rgb(var(--color-a-b) / calc(var(--opacity-a-b, 1) * <alpha-value>))",
             "a-b-light": "#ffffff",
             "a-b-dark": "#000000",
           },
@@ -52,7 +52,7 @@ describe("With -light- and -dark- segments in the middle", () => {
       expect.objectContaining({
         theme: {
           colors: {
-            "a-b-c": "rgba(var(--color-a-b-c))",
+            "a-b-c": "rgb(var(--color-a-b-c) / calc(var(--opacity-a-b-c, 1) * <alpha-value>))",
             "a-b-light-c": "#ffffff",
             "a-b-dark-c": "#000000",
           },
@@ -81,7 +81,7 @@ describe("With light- and dark- segments at the start", () => {
       expect.objectContaining({
         theme: {
           colors: {
-            a: "rgba(var(--color-a))",
+            a: "rgb(var(--color-a) / calc(var(--opacity-a, 1) * <alpha-value>))",
             "light-a": "#ffffff",
             "dark-a": "#000000",
           },
@@ -111,7 +111,7 @@ describe("With custom light and dark ids", () => {
       expect.objectContaining({
         theme: {
           colors: {
-            a: "rgba(var(--color-a))",
+            a: "rgb(var(--color-a) / calc(var(--opacity-a, 1) * <alpha-value>))",
             "a-claro": "#ffffff",
             "a-oscuro": "#000000",
           },

--- a/tests/outlineColor.test.js
+++ b/tests/outlineColor.test.js
@@ -18,7 +18,7 @@ describe("outlineColor theme", () => {
       expect.objectContaining({
         theme: {
           outlineColor: {
-            a: "rgb(var(--color-outline-a) / <alpha-value>)",
+            a: "rgba(var(--color-outline-a))",
             "a-light": "#ffffff",
             "a-dark": "#000000",
           },
@@ -47,7 +47,7 @@ describe("outlineColor theme", () => {
           theme: {
             extend: {
               outlineColor: {
-                a: "rgb(var(--color-outline-a) / <alpha-value>)",
+                a: "rgba(var(--color-outline-a))",
                 "a-light": "#ffffff",
                 "a-dark": "#000000",
               },
@@ -94,7 +94,7 @@ describe("outlineColor theme", () => {
         expect(utilitiesCSS.replace(/\n|\s|\t/g, "")).toBe(
           `
           .outline-a\\/50 {
-            outline-color: rgb(var(--color-outline-a) / 0.5)
+            outline-color: rgba(var(--color-outline-a), 0.5)
           }
           `.replace(/\n|\s|\t/g, "")
         );
@@ -105,12 +105,12 @@ describe("outlineColor theme", () => {
 
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `html {
-          --color-outline-a: 255 255 255;
+          --color-outline-a: 255, 255, 255;
         }`.replace(/\n|\s|\t/g, "")
         );
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `${expectedSelector} {
-          --color-outline-a: 0 0 0;
+          --color-outline-a: 0, 0, 0;
         }`.replace(/\n|\s|\t/g, "")
         );
       });

--- a/tests/outlineColor.test.js
+++ b/tests/outlineColor.test.js
@@ -18,7 +18,7 @@ describe("outlineColor theme", () => {
       expect.objectContaining({
         theme: {
           outlineColor: {
-            a: "rgba(var(--color-outline-a))",
+            a: "rgb(var(--color-outline-a) / calc(var(--opacity-outline-a, 1) * <alpha-value>))",
             "a-light": "#ffffff",
             "a-dark": "#000000",
           },
@@ -47,7 +47,7 @@ describe("outlineColor theme", () => {
           theme: {
             extend: {
               outlineColor: {
-                a: "rgba(var(--color-outline-a))",
+                a: "rgb(var(--color-outline-a) / calc(var(--opacity-outline-a, 1) * <alpha-value>))",
                 "a-light": "#ffffff",
                 "a-dark": "#000000",
               },
@@ -74,7 +74,7 @@ describe("outlineColor theme", () => {
           darkMode: darkModeConfig,
           content: [
             {
-              raw: "bg-a/50 text-a border-a outline-a/50 dark something custom-selector",
+              raw: "bg-a/50 text-a border-a outline-b/50 outline-a dark something custom-selector",
             },
           ],
           theme: {
@@ -82,6 +82,10 @@ describe("outlineColor theme", () => {
               a: {
                 light: "#ffffff",
                 dark: "#000000",
+              },
+              b: {
+                light: "rgba(255, 255, 255, 0.2)",
+                dark: "rgba(0, 0, 0, 0.2)",
               },
             },
           },
@@ -93,8 +97,11 @@ describe("outlineColor theme", () => {
 
         expect(utilitiesCSS.replace(/\n|\s|\t/g, "")).toBe(
           `
-          .outline-a\\/50 {
-            outline-color: rgba(var(--color-outline-a), 0.5)
+          .outline-a {
+            outline-color: rgb(var(--color-outline-a) / calc(var(--opacity-outline-a, 1) * 1))
+          }
+          .outline-b\\/50 {
+            outline-color: rgb(var(--color-outline-b) / calc(var(--opacity-outline-b, 1) * 0.5))
           }
           `.replace(/\n|\s|\t/g, "")
         );
@@ -105,12 +112,16 @@ describe("outlineColor theme", () => {
 
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `html {
-          --color-outline-a: 255, 255, 255;
+          --color-outline-a: 255 255 255;
+          --color-outline-b: 255 255 255;
+          --opacity-outline-b: 20%;
         }`.replace(/\n|\s|\t/g, "")
         );
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `${expectedSelector} {
-          --color-outline-a: 0, 0, 0;
+          --color-outline-a: 0 0 0;
+          --color-outline-b: 0 0 0;
+          --opacity-outline-b: 20%;
         }`.replace(/\n|\s|\t/g, "")
         );
       });

--- a/tests/outlineColor.test.js
+++ b/tests/outlineColor.test.js
@@ -2,23 +2,23 @@ const withModeAwareColors = require("../src/index");
 const postcss = require("postcss");
 
 describe("outlineColor theme", () => {
-  it("Flattens color map and adds mode aware color", () => {
-    expect(
-      withModeAwareColors({
-        theme: {
-          outlineColor: {
-            a: {
-              light: "#ffffff",
-              dark: "#000000",
-            },
-          },
+  const config = withModeAwareColors({
+    theme: {
+      outlineColor: {
+        a: {
+          light: "#ffffff",
+          dark: "#000000",
         },
-      })
-    ).toEqual(
+      },
+    },
+  });
+
+  it("Flattens color map and adds mode aware color", () => {
+    expect(config).toEqual(
       expect.objectContaining({
         theme: {
           outlineColor: {
-            a: "rgb(var(--color-outline-a) / calc(var(--opacity-outline-a, 1) * <alpha-value>))",
+            a: expect.any(Function),
             "a-light": "#ffffff",
             "a-dark": "#000000",
           },
@@ -27,33 +27,59 @@ describe("outlineColor theme", () => {
     );
   });
 
+  it("Defines mode aware color as a function based on opacity", () => {
+    const a = config.theme.outlineColor.a;
+    expect(a({})).toEqual(
+      "rgb(var(--color-outline-a) / var(--opacity-outline-a, 1))"
+    );
+    expect(a({ opacityValue: 0.4 })).toEqual(
+      "rgb(var(--color-outline-a) / 0.4)"
+    );
+    expect(a({ opacityValue: "var(--tw-outline-opacity)" })).toEqual(
+      "rgb(var(--color-outline-a) / var(--opacity-outline-a, var(--tw-outline-opacity)))"
+    );
+  });
+
   describe("extend", () => {
-    it("Flattens extend color map and adds mode aware color", () => {
-      expect(
-        withModeAwareColors({
-          theme: {
-            extend: {
-              outlineColor: {
-                a: {
-                  light: "#ffffff",
-                  dark: "#000000",
-                },
-              },
+    const config = withModeAwareColors({
+      theme: {
+        extend: {
+          outlineColor: {
+            a: {
+              light: "#ffffff",
+              dark: "#000000",
             },
           },
-        })
-      ).toEqual(
+        },
+      },
+    });
+
+    it("Flattens extend color map and adds mode aware color", () => {
+      expect(config).toEqual(
         expect.objectContaining({
           theme: {
             extend: {
               outlineColor: {
-                a: "rgb(var(--color-outline-a) / calc(var(--opacity-outline-a, 1) * <alpha-value>))",
+                a: expect.any(Function),
                 "a-light": "#ffffff",
                 "a-dark": "#000000",
               },
             },
           },
         })
+      );
+    });
+
+    it("Defines mode aware color as a function based on opacity", () => {
+      const a = config.theme.extend.outlineColor.a;
+      expect(a({})).toEqual(
+        "rgb(var(--color-outline-a) / var(--opacity-outline-a, 1))"
+      );
+      expect(a({ opacityValue: 0.4 })).toEqual(
+        "rgb(var(--color-outline-a) / 0.4)"
+      );
+      expect(a({ opacityValue: "var(--tw-outline-opacity)" })).toEqual(
+        "rgb(var(--color-outline-a) / var(--opacity-outline-a, var(--tw-outline-opacity)))"
       );
     });
   });
@@ -74,7 +100,7 @@ describe("outlineColor theme", () => {
           darkMode: darkModeConfig,
           content: [
             {
-              raw: "bg-a/50 text-a border-a outline-b/50 outline-a dark something custom-selector",
+              raw: "bg-a/50 text-a border-a outline-b outline-b/50 outline-a dark something custom-selector",
             },
           ],
           theme: {
@@ -98,10 +124,13 @@ describe("outlineColor theme", () => {
         expect(utilitiesCSS.replace(/\n|\s|\t/g, "")).toBe(
           `
           .outline-a {
-            outline-color: rgb(var(--color-outline-a) / calc(var(--opacity-outline-a, 1) * 1))
+            outline-color: rgb(var(--color-outline-a) / var(--opacity-outline-a, 1))
+          }
+          .outline-b {
+            outline-color: rgb(var(--color-outline-b) / var(--opacity-outline-b, 1))
           }
           .outline-b\\/50 {
-            outline-color: rgb(var(--color-outline-b) / calc(var(--opacity-outline-b, 1) * 0.5))
+            outline-color: rgb(var(--color-outline-b) / 0.5)
           }
           `.replace(/\n|\s|\t/g, "")
         );

--- a/tests/textColor.test.js
+++ b/tests/textColor.test.js
@@ -2,23 +2,22 @@ const withModeAwareColors = require("../src/index");
 const postcss = require("postcss");
 
 describe("textColor theme", () => {
+  const theme = {
+    textColor: {
+      a: {
+        light: "#ffffff",
+        dark: "#000000",
+      },
+    },
+  };
+  const config = withModeAwareColors({ theme });
+
   it("Flattens color map and adds mode aware color", () => {
-    expect(
-      withModeAwareColors({
-        theme: {
-          textColor: {
-            a: {
-              light: "#ffffff",
-              dark: "#000000",
-            },
-          },
-        },
-      })
-    ).toEqual(
+    expect(config).toEqual(
       expect.objectContaining({
         theme: {
           textColor: {
-            a: "rgb(var(--color-text-a) / calc(var(--opacity-text-a, 1) * <alpha-value>))",
+            a: expect.any(Function),
             "a-light": "#ffffff",
             "a-dark": "#000000",
           },
@@ -27,33 +26,56 @@ describe("textColor theme", () => {
     );
   });
 
+  it("Defines mode aware color as a function based on opacity", () => {
+    const a = config.theme.textColor.a;
+    expect(a({})).toEqual(
+      "rgb(var(--color-text-a) / var(--opacity-text-a, 1))"
+    );
+    expect(a({ opacityValue: 0.4 })).toEqual("rgb(var(--color-text-a) / 0.4)");
+    expect(a({ opacityValue: "var(--tw-text-opacity)" })).toEqual(
+      "rgb(var(--color-text-a) / var(--opacity-text-a, var(--tw-text-opacity)))"
+    );
+  });
+
   describe("extend", () => {
-    it("Flattens extend color map and adds mode aware color", () => {
-      expect(
-        withModeAwareColors({
-          theme: {
-            extend: {
-              textColor: {
-                a: {
-                  light: "#ffffff",
-                  dark: "#000000",
-                },
-              },
-            },
+    const theme = {
+      extend: {
+        textColor: {
+          a: {
+            light: "#ffffff",
+            dark: "#000000",
           },
-        })
-      ).toEqual(
+        },
+      },
+    };
+    const config = withModeAwareColors({ theme });
+
+    it("Flattens extend color map and adds mode aware color", () => {
+      expect(config).toEqual(
         expect.objectContaining({
           theme: {
             extend: {
               textColor: {
-                a: "rgb(var(--color-text-a) / calc(var(--opacity-text-a, 1) * <alpha-value>))",
+                a: expect.any(Function),
                 "a-light": "#ffffff",
                 "a-dark": "#000000",
               },
             },
           },
         })
+      );
+    });
+
+    it("Defines mode aware color as a function based on opacity", () => {
+      const a = config.theme.extend.textColor.a;
+      expect(a({})).toEqual(
+        "rgb(var(--color-text-a) / var(--opacity-text-a, 1))"
+      );
+      expect(a({ opacityValue: 0.4 })).toEqual(
+        "rgb(var(--color-text-a) / 0.4)"
+      );
+      expect(a({ opacityValue: "var(--tw-text-opacity)" })).toEqual(
+        "rgb(var(--color-text-a) / var(--opacity-text-a, var(--tw-text-opacity)))"
       );
     });
   });
@@ -94,7 +116,7 @@ describe("textColor theme", () => {
         expect(utilitiesCSS.replace(/\n|\s|\t/g, "")).toBe(
           `
           .text-a\\/50 {
-            color: rgb(var(--color-text-a) / calc(var(--opacity-text-a, 1) * 0.5))
+            color: rgb(var(--color-text-a) / 0.5)
           }
           `.replace(/\n|\s|\t/g, "")
         );

--- a/tests/textColor.test.js
+++ b/tests/textColor.test.js
@@ -18,7 +18,7 @@ describe("textColor theme", () => {
       expect.objectContaining({
         theme: {
           textColor: {
-            a: "rgb(var(--color-text-a) / <alpha-value>)",
+            a: "rgba(var(--color-text-a))",
             "a-light": "#ffffff",
             "a-dark": "#000000",
           },
@@ -47,7 +47,7 @@ describe("textColor theme", () => {
           theme: {
             extend: {
               textColor: {
-                a: "rgb(var(--color-text-a) / <alpha-value>)",
+                a: "rgba(var(--color-text-a))",
                 "a-light": "#ffffff",
                 "a-dark": "#000000",
               },
@@ -94,7 +94,7 @@ describe("textColor theme", () => {
         expect(utilitiesCSS.replace(/\n|\s|\t/g, "")).toBe(
           `
           .text-a\\/50 {
-            color: rgb(var(--color-text-a) / 0.5)
+            color: rgba(var(--color-text-a), 0.5)
           }
           `.replace(/\n|\s|\t/g, "")
         );
@@ -105,12 +105,12 @@ describe("textColor theme", () => {
 
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `html {
-          --color-text-a: 255 255 255;
+          --color-text-a: 255, 255, 255;
         }`.replace(/\n|\s|\t/g, "")
         );
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `${expectedSelector} {
-          --color-text-a: 0 0 0;
+          --color-text-a: 0, 0, 0;
         }`.replace(/\n|\s|\t/g, "")
         );
       });

--- a/tests/textColor.test.js
+++ b/tests/textColor.test.js
@@ -18,7 +18,7 @@ describe("textColor theme", () => {
       expect.objectContaining({
         theme: {
           textColor: {
-            a: "rgba(var(--color-text-a))",
+            a: "rgb(var(--color-text-a) / calc(var(--opacity-text-a, 1) * <alpha-value>))",
             "a-light": "#ffffff",
             "a-dark": "#000000",
           },
@@ -47,7 +47,7 @@ describe("textColor theme", () => {
           theme: {
             extend: {
               textColor: {
-                a: "rgba(var(--color-text-a))",
+                a: "rgb(var(--color-text-a) / calc(var(--opacity-text-a, 1) * <alpha-value>))",
                 "a-light": "#ffffff",
                 "a-dark": "#000000",
               },
@@ -94,7 +94,7 @@ describe("textColor theme", () => {
         expect(utilitiesCSS.replace(/\n|\s|\t/g, "")).toBe(
           `
           .text-a\\/50 {
-            color: rgba(var(--color-text-a), 0.5)
+            color: rgb(var(--color-text-a) / calc(var(--opacity-text-a, 1) * 0.5))
           }
           `.replace(/\n|\s|\t/g, "")
         );
@@ -105,12 +105,12 @@ describe("textColor theme", () => {
 
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `html {
-          --color-text-a: 255, 255, 255;
+          --color-text-a: 255 255 255;
         }`.replace(/\n|\s|\t/g, "")
         );
         expect(baseCSS.replace(/\n|\s|\t/g, "")).toContain(
           `${expectedSelector} {
-          --color-text-a: 0, 0, 0;
+          --color-text-a: 0 0 0;
         }`.replace(/\n|\s|\t/g, "")
         );
       });


### PR DESCRIPTION
Huge thanks to @PretzelJohn for bringing this up and coming up with the initial implementation in #4. Sorry for taking so long to respond, I couldn't find the time until now.

I've peeked into the Tailwind internals and reworked it so the opacity modifiers work just as Vanilla Tailwind does. Turns out we can define colors as JS functions, which makes things so much easier.

I'll keep the PR open for a few days so you hopefully get a chance to look at it @PretzelJohn.