### PR TITLE
Add type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
   "license": "MIT",
   "repository": "https://github.com/JavierM42/tailwind-mode-aware-colors",
   "scripts": {
-    "test": "jest"
+    "test": "jest && tsd -t './src/index.d.ts'"
   },
   "dependencies": {
-    "color": "^4.2.3"
+    "color": "^4.2.3",
+    "type-fest": "^4.10.1"
   },
   "peerDependencies": {
     "tailwindcss": "^3.1.0"
@@ -31,5 +32,11 @@
     "postcss": "^8.2.4",
     "tsd": "^0.30.4"
   },
-  "author": "Javier Morales"
+  "author": "Javier Morales",
+  "tsd": {
+    "directory": "tests",
+    "compilerOptions": {
+      "noImplicitAny": false
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   ],
   "devDependencies": {
     "jest": "^27.2.4",
-    "postcss": "^8.2.4"
+    "postcss": "^8.2.4",
+    "tsd": "^0.30.4"
   },
   "author": "Javier Morales"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "tailwind-mode-aware-colors",
   "version": "1.4.1",
   "description": "TailwindCSS Plugin to generate dynamic colors that will automatically switch between light and dark mode variants.",
-  "main": "src/index.js",
+  "exports": {
+    "require": "./src/index.js",
+    "types": "./src/index.d.ts"
+  },
   "license": "MIT",
   "repository": "https://github.com/JavierM42/tailwind-mode-aware-colors",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "test": "jest && tsd -t './src/index.d.ts'"
   },
   "dependencies": {
-    "color": "^4.2.3",
-    "type-fest": "^4.10.1"
+    "color": "^4.2.3"
   },
   "peerDependencies": {
     "tailwindcss": "^3.1.0"

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,12 +1,4 @@
-import type { Config as TailwindConfig } from "tailwindcss";
-import type { RecursiveKeyValuePair } from "tailwindcss/types/config";
-import type { MergeDeep } from "type-fest";
-
-type Config = MergeDeep<TailwindConfig, {
-  theme?: {
-    colors?: RecursiveKeyValuePair;
-  };
-}>;
+import type { Config } from "tailwindcss";
 
 type Options = {
   /** @default "light" */

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,10 +1,15 @@
 import type { Config } from "tailwindcss";
+import type { RecursiveKeyValuePair } from "tailwindcss/types/config";
+
+interface ThemeConfig {
+  colors?: RecursiveKeyValuePair;
+}
 
 type Options = {
   /** @default "light" */
-  lightId: string;
+  lightId?: string;
   /** @default "dark" */
-  darkId: string;
+  darkId?: string;
 };
 
 /**
@@ -30,4 +35,4 @@ type Options = {
  * });
  * ```
  */
-export default function withModeAwareColors(config: Config, options: Options): Config;
+export default function withModeAwareColors(config: Config, options?: Options): Config;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -30,4 +30,4 @@ type Options = {
  * });
  * ```
  */
-export default function (config: Config, options: Options): Config;
+export default function withModeAwareColors(config: Config, options: Options): Config;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -20,6 +20,8 @@ type Options = {
  *
  * With this plugin, `bg-primary` can be used instead of `bg-primary-light dark:bg-primary-dark`.
  *
+ * @warning Colors must be defined as an object (not a function) for the plugin to work.
+ *
  * @example
  * ```
  * module.exports = require('tailwind-mode-aware-colors')({

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,9 +1,12 @@
-import type { Config } from "tailwindcss";
+import type { Config as TailwindConfig } from "tailwindcss";
 import type { RecursiveKeyValuePair } from "tailwindcss/types/config";
+import type { MergeDeep } from "type-fest";
 
-interface ThemeConfig {
-  colors?: RecursiveKeyValuePair;
-}
+type Config = MergeDeep<TailwindConfig, {
+  theme?: {
+    colors?: RecursiveKeyValuePair;
+  };
+}>;
 
 type Options = {
   /** @default "light" */

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,33 @@
+import type { Config } from "tailwindcss";
+
+type Options = {
+  /** @default "light" */
+  lightId: string;
+  /** @default "dark" */
+  darkId: string;
+};
+
+/**
+ * Adds dynamic colors to TailwindCSS with light and dark shades that are shown based on the user's color scheme.
+ *
+ * With this plugin, `bg-primary` can be used instead of `bg-primary-light dark:bg-primary-dark`.
+ *
+ * @example
+ * ```
+ * module.exports = require('tailwind-mode-aware-colors')({
+ *   // your usual config
+ *   theme: {
+ *     colors: {
+ *       primary: {
+ *         // colors defined with light and dark keys will be dynamic
+ *         light: '#bbffa3',
+ *         dark: '#144b00'
+ *       }
+ *       ...
+ *     }
+ *   }
+ *   ...
+ * });
+ * ```
+ */
+export default function (config: Config, options: Options): Config;

--- a/tests/index.test-d.ts
+++ b/tests/index.test-d.ts
@@ -7,6 +7,9 @@ type Options = NonNullable<Parameters<typeof withModeAwareColors>[1]>;
 withModeAwareColors({
   content: ["./index.html"],
   theme: {
+    container: {
+      center: true,
+    },
     colors: {
       a: colors.white,
       b: {
@@ -21,7 +24,13 @@ withModeAwareColors({
         },
       },
     },
+    extend: {
+      width: {
+        prose: "65ch",
+      },
+    },
   },
+  plugins: [],
 });
 
 withModeAwareColors({
@@ -39,7 +48,7 @@ withModeAwareColors({
   darkId: "oscuro",
 });
 
-expectError(
+expectError(() => {
   withModeAwareColors({
     content: ["./index.html"],
     theme: {
@@ -48,7 +57,7 @@ expectError(
       }),
     },
   })
-)
+});
 
 expectAssignable<Options>({
   lightId: "claro",

--- a/tests/index.test-d.ts
+++ b/tests/index.test-d.ts
@@ -48,15 +48,14 @@ withModeAwareColors({
   darkId: "oscuro",
 });
 
-expectError(() => {
-  withModeAwareColors({
-    content: ["./index.html"],
-    theme: {
-      colors: ({ colors }) => ({
-        a: colors.white,
-      }),
-    },
-  })
+// Invalid form: see discussion is #8
+withModeAwareColors({
+  content: ["./index.html"],
+  theme: {
+    colors: ({ colors }) => ({
+      a: colors.white,
+    }),
+  },
 });
 
 expectAssignable<Options>({

--- a/tests/index.test-d.ts
+++ b/tests/index.test-d.ts
@@ -1,0 +1,70 @@
+import {expectAssignable, expectError} from 'tsd';
+import colors from "tailwindcss/colors";
+import withModeAwareColors from "../src/index";
+
+type Options = NonNullable<Parameters<typeof withModeAwareColors>[1]>;
+
+withModeAwareColors({
+  content: ["./index.html"],
+  theme: {
+    colors: {
+      a: colors.white,
+      b: {
+        light: "#fcfcfc",
+        dark: "#030303",
+      },
+      c: {
+        DEFAULT: "#ffffff33",
+        muted: {
+          light: "#fefefe33",
+          dark: "#00000033",
+        },
+      },
+    },
+  },
+});
+
+withModeAwareColors({
+  content: ["./index.html"],
+  theme: {
+    colors: {
+      a: {
+        light: "#fcfcfc",
+        dark: "#030303",
+      },
+    },
+  },
+}, {
+  lightId: "claro",
+  darkId: "oscuro",
+});
+
+expectError(
+  withModeAwareColors({
+    content: ["./index.html"],
+    theme: {
+      colors: ({ colors }) => ({
+        a: colors.white,
+      }),
+    },
+  })
+)
+
+expectAssignable<Options>({
+  lightId: "claro",
+  darkId: "oscuro",
+});
+
+expectAssignable<Options>({
+  lightId: "claro",
+});
+
+expectAssignable<Options>({
+  darkId: "oscuro",
+});
+
+expectAssignable<Options>({});
+
+expectError<Options>({
+  extra: "extra",
+});


### PR DESCRIPTION
Adds `src/index.d.ts` and changes the `"main"` field in `package.json` to `"exports"` ([[1]](https://nodejs.org/api/packages.html#exports), [[2]](https://webpack.js.org/guides/package-exports/)).

I can add type tests as well, if you'd like (I'm partial to [`tsd`](https://github.com/tsdjs/tsd)).